### PR TITLE
Potential fix for code scanning alert no. 4: Exposure of private files

### DIFF
--- a/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.js
+++ b/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.js
@@ -28,7 +28,7 @@ app.get('/', (req, res) => {
 })
 
 // This is to allow files to be accessible
-app.use(express.static(__dirname + '/'))
+app.use('/Javascript/Webpage', express.static(__dirname + '/Javascript/Webpage'))
 
 // This is to listen to the correct port
 http.listen(port, () => {


### PR DESCRIPTION
Potential fix for [https://github.com/umati/UA-for-Industrial-Joining-Technologies/security/code-scanning/4](https://github.com/umati/UA-for-Industrial-Joining-Technologies/security/code-scanning/4)

To fix the problem, we need to limit the directories that are served by the Express application to only those that are intended to be publicly accessible. This involves specifying the exact subdirectories that contain static files meant for public access, rather than serving the entire directory.

- Identify the specific subdirectories within `__dirname` that should be publicly accessible.
- Replace the line `app.use(express.static(__dirname + '/'))` with lines that serve only the intended subdirectories.
- Ensure that no sensitive directories or files are exposed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
