### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.js
+++ b/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.js
@@ -48,5 +48,5 @@ http.listen(port, () => {
 });
 
 // ----------------------------- SocketIO -----------------------------
-const nodeOPCUAInterface = new NodeOPCUAInterface(io, AttributeIds, OPCUAClient);
+const nodeOPCUAInterface = new NodeOPCUAInterface(io, AttributeIds);
 nodeOPCUAInterface.setupSocketIO(OPCUAClient);


### PR DESCRIPTION
In general, the fix is to ensure that the number of arguments passed to a constructor matches its declared parameters. If an argument is not used by the constructor (and not read via `arguments`/rest parameters), it should be removed at the callsite to avoid confusion and static-analysis warnings.

The single best fix here, without changing existing functionality, is to remove the extra `OPCUAClient` argument from the `new NodeOPCUAInterface(...)` call on line 51, leaving only the arguments that the constructor is declared to accept. The separate call on line 52, `nodeOPCUAInterface.setupSocketIO(OPCUAClient);`, appears to be the correct/intentional place where `OPCUAClient` is used, so that line should remain unchanged. No imports or additional methods are needed; we only adjust the single constructor call in `OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.js`.

Concretely:
- In `OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.js`, edit line 51 to remove the third argument, changing:
  - `const nodeOPCUAInterface = new NodeOPCUAInterface(io, AttributeIds, OPCUAClient);`
  - to:
  - `const nodeOPCUAInterface = new NodeOPCUAInterface(io, AttributeIds);`
- Leave all other code unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._