### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/Assets/AssetGraphics.mjs
+++ b/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/Assets/AssetGraphics.mjs
@@ -6,7 +6,7 @@ import BasicScreen from '../GraphicSupport/BasicScreen.mjs'
  */
 export default class AssetGraphics extends BasicScreen {
   constructor (assetManager) {
-    super('Assets', 'tighteningsystem')
+    super('Assets')
     this.assetManager = assetManager
 
     const displayArea = document.createElement('div')


### PR DESCRIPTION
In general, to fix this issue you should align the number of arguments in the constructor call with the number of parameters actually used by the base class constructor. Extra trailing arguments that are not consumed should be removed to avoid confusion and potential maintenance errors.

For this specific case, adjust the `AssetGraphics` constructor so that it calls `super` with only the arguments that `BasicScreen` actually uses. Since CodeQL flags `'tighteningsystem'` as superfluous, the least invasive and functionally safe change (based solely on this file) is to remove that second argument and keep only the `'Assets'` title. No other behavior in `AssetGraphics` references `'tighteningsystem'`, so making this change does not affect any code within this snippet.

Implementation steps (within `OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/Assets/AssetGraphics.mjs`):

- In the `constructor (assetManager) { ... }` block of `AssetGraphics`, edit the `super` call on line 9.
- Change `super('Assets', 'tighteningsystem')` to `super('Assets')`.
- No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._