### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/OPC_UA_Clients/Release1/basic_node_opcua/client.ts
+++ b/OPC_UA_Clients/Release1/basic_node_opcua/client.ts
@@ -20,7 +20,6 @@ import {
 
 const endpointUrl = 'opc.tcp://127.0.0.1:40451';
 
-
 async function main() {
     const client = OPCUAClient.create({
         endpointMustExist: false,

--- a/OPC_UA_Clients/Release1/basic_node_opcua/client.ts
+++ b/OPC_UA_Clients/Release1/basic_node_opcua/client.ts
@@ -19,7 +19,6 @@ import {
 
 
 const endpointUrl = 'opc.tcp://127.0.0.1:40451';
-const nodeId = 'ns=1;s=/ObjectsFolder/TighteningSystem/ResultManagement/Results/Result';
 
 
 async function main() {


### PR DESCRIPTION
In general, to fix an unused-variable issue, either remove the unused declaration or start using it meaningfully. Here, the constant `nodeId` at line 22 is completely unused and a separate `nodeId` local is already used inside the loop, so the cleanest fix that preserves existing behavior is to delete the unused top-level constant. No new behavior is required, and we do not want to force the rest of the code to use this value because that would change semantics.

Concretely, in `OPC_UA_Clients/Release1/basic_node_opcua/client.ts`, remove the line declaring `const nodeId = 'ns=1;s=/ObjectsFolder/TighteningSystem/ResultManagement/Results/Result';`. No imports or other code changes are necessary, and no additional definitions or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._