### PR TITLE
Fix for Empty except

### DIFF
--- a/OPC_UA_Clients/Release2/IJT_Web_Client/tests/test_shared_client_contract.py
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/tests/test_shared_client_contract.py
@@ -32,7 +32,9 @@ def _is_websocket_startup_error(exc: Exception) -> bool:
                 ws_related.append(typ)
         if ws_related and isinstance(exc, tuple(ws_related)):
             return True
-    except Exception:
+    except (ImportError, AttributeError):
+        # If the optional 'websockets' dependency is missing or does not expose
+        # the expected exception types, fall back to the heuristic checks below.
         pass
 
     msg = str(exc).lower()


### PR DESCRIPTION
In general, the problem is that a broad `except Exception:` is used with an empty body (`pass`) and no comment. To fix it without changing the external behavior, we should either (1) narrow the caught exception types and/or (2) add minimal behavior (such as a comment or logging) that documents the intent while keeping the functional outcome the same, i.e., falling back to the string-based detection logic below.

The best way here is to keep the logic the same—failed imports or introspection of `websockets.exceptions` should simply disable that specific check—but make that intent explicit and ensure that only expected errors are swallowed. We can do this by narrowing the except to `ImportError` and `AttributeError` (which cover typical import and attribute lookup failures) and adding a short comment explaining that we fall back to heuristic checks when `websockets` is unavailable or incompatible. This does not alter the function’s behavior for those expected failure modes, but removes the “do nothing” anti-pattern and clarifies the rationale. Since we only modify the existing `except` block inside `_is_websocket_startup_error`, no new imports or helper methods are required, and no other files need changes.

Concretely, in `OPC_UA_Clients/Release2/IJT_Web_Client/tests/test_shared_client_contract.py`, replace the `except Exception:` / `pass` block in `_is_websocket_startup_error` with an `except (ImportError, AttributeError):` block that contains a brief explanatory comment and a `pass`. This satisfies the CodeQL rule while keeping the function semantics intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._