### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/GraphicSupport/ControlMessageSplitScreen.mjs
+++ b/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/GraphicSupport/ControlMessageSplitScreen.mjs
@@ -7,7 +7,7 @@ import BasicScreen from './BasicScreen.mjs'
  */
 export default class ControlMessageSplitScreen extends BasicScreen {
   constructor (title, leftText, rightText, activationPhase) {
-    super(title, activationPhase)
+    super(title)
 
     const columnSetter = document.createElement('div')
     columnSetter.classList.add('columns')


### PR DESCRIPTION
To fix the problem, we should stop passing a superfluous argument to the `BasicScreen` constructor. Since JavaScript ignores extra arguments, removing the extra argument will not change existing behavior but will align the call with the base class’s expected arity and address the CodeQL warning.

The minimal, behavior-preserving fix in this snippet is to change the `super` call from `super(title, activationPhase)` to `super(title)` and leave the rest of the constructor unchanged. This keeps the public signature of `ControlMessageSplitScreen` intact—so external callers that pass `activationPhase` will still compile and run—but it avoids passing that value to `BasicScreen` if `BasicScreen` does not expect it. If later we decide `activationPhase` should affect `ControlMessageSplitScreen` itself, it can be used inside this constructor or stored as a field without impacting the base class.

Concretely, in `OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/GraphicSupport/ControlMessageSplitScreen.mjs`, on line 10, update the `super` invocation to take only `title` as argument. No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._