### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.html
+++ b/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.html
@@ -37,7 +37,6 @@
 
     import ServerGraphics from 'views/Servers/ServerGraphics.mjs';
     import TabGenerator from 'views/GraphicSupport/TabGenerator.mjs';
-    import EndpointGraphics from 'views/Servers/EndpointGraphics.mjs';
 
     // Set up websocket to the server
     const socket = io();


### PR DESCRIPTION
In general, unused imports should be removed or, if the module is needed only for its side effects, converted to a side-effect-only import. This keeps the codebase cleaner and avoids misleading future readers and static analysis tools.

For this specific case in `OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/index.html`, the single best fix is to delete the unused import line:

```js
import EndpointGraphics from 'views/Servers/EndpointGraphics.mjs';
```

No other code references `EndpointGraphics`, and there is no indication that this module is required for side effects. Removing only this line does not change any existing functionality in the shown code and resolves the CodeQL warning. No new methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._