### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/Servers/EndpointGraphics.mjs
+++ b/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/Servers/EndpointGraphics.mjs
@@ -3,7 +3,6 @@
  */
 import {
   AddressSpace,
-  AssetManager,
   MethodManager,
   EventManager,
   ResultManager,


### PR DESCRIPTION
In general, unused imports should be removed to keep the code clean and avoid confusion about dependencies. Since `AssetManager` is not referenced anywhere in the active code in `EndpointGraphics.mjs`, the best fix is to remove `AssetManager` from the named imports list while leaving the rest of the import intact.

Concretely, in `OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/Views/Servers/EndpointGraphics.mjs`, edit the import statement at the top of the file. Remove `AssetManager` from the destructuring import so that only the actually used classes (`AddressSpace`, `MethodManager`, `EventManager`, `ResultManager`, `ModelManager`, `ConnectionManager`) remain. No new methods, definitions, or additional imports are needed, and the commented-out lines involving `AssetManager` and `AssetGraphics` can remain as comments (they already do not affect the code).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._