### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/ijt-support/Models/ModelManager.mjs
+++ b/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/ijt-support/Models/ModelManager.mjs
@@ -1,5 +1,4 @@
 /* eslint-disable */
-import ResultValueDataType from './ResultValueDataType.mjs'
 import ResultDataType from './ResultDataModel.mjs'
 import StepResultDataType from './StepResultDataType.mjs'
 import TagDataType from './TagDataType.mjs'


### PR DESCRIPTION
In general, the fix is to remove unused imports so that every imported symbol is referenced somewhere in the file or to start using that symbol if it was mistakenly left unused. This reduces noise, avoids confusion, and can slightly improve performance/build times.

For this specific case, the simplest and safest fix without changing functionality is to delete the unused import on line 2: `import ResultValueDataType from './ResultValueDataType.mjs'`. No other code changes are needed because no references to `ResultValueDataType` exist in the shown snippet. The file to modify is `OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/ijt-support/Models/ModelManager.mjs`, at the top where the imports are declared. No new methods, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._