### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/ijt-support/Models/ModelManager.mjs
+++ b/OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/ijt-support/Models/ModelManager.mjs
@@ -2,7 +2,6 @@
 import ResultDataType from './ResultDataModel.mjs'
 import StepResultDataType from './StepResultDataType.mjs'
 import TagDataType from './TagDataType.mjs'
-import { TighteningTraceDataType, StepTraceDataType, TraceContentDataType, TraceValueDataType } from './TighteningTraceDataType.mjs'
 /* eslint-disable */
 export class ModelManager {
   /**


### PR DESCRIPTION
In general, unused imports should be removed to keep the codebase clean, avoid confusion, and potentially reduce bundle size. Since these four imported types are not referenced anywhere in the given `ModelManager` implementation, the best fix is simply to delete them from the import statement.

Concretely, in `OPC_UA_Clients/Release1/NodeOPCUA_IJT_Client/Javascripts/ijt-support/Models/ModelManager.mjs`, modify the import on line 5 to remove the destructured import of `TighteningTraceDataType`, `StepTraceDataType`, `TraceContentDataType`, and `TraceValueDataType`. Leave the rest of the file unchanged. No additional methods or definitions are needed, and no other lines require modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._