### PR TITLE
Fix for Unused import

### DIFF
--- a/OPC_UA_Servers/Release2/tests/smoke_test.py
+++ b/OPC_UA_Servers/Release2/tests/smoke_test.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import contextlib
 import socket
 import sys
 import time


### PR DESCRIPTION
To fix an unused import, the general approach is simply to remove the import statement, provided it truly is not referenced anywhere in the file. This eliminates the lint/static-analysis warning without altering runtime behavior.

In this specific case, in `OPC_UA_Servers/Release2/tests/smoke_test.py`, we should delete the line `import contextlib` (line 25). No other changes are needed, and no additional imports or definitions are required. Make sure only that single import line is removed and that the surrounding imports (argparse, asyncio, socket, sys, time, typing.Any, and the asyncua imports) remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._