### PR TITLE
Add IJT Browser CI Image Build Path

### DIFF
--- a/.github/docker/ijt-browser-ci/Dockerfile
+++ b/.github/docker/ijt-browser-ci/Dockerfile
@@ -83,7 +83,13 @@ RUN python -m pip install --upgrade pip \
  && python -m pip wheel --pre \
         -r /tmp/requirements.txt \
         -r /tmp/requirements-dev.txt \
-        --wheel-dir /opt/ijt-browser-ci/pip-wheelhouse
+        --wheel-dir /opt/ijt-browser-ci/pip-wheelhouse \
+ && python -m pip install --pre \
+        --no-index \
+        --find-links /opt/ijt-browser-ci/pip-wheelhouse \
+        -r /tmp/requirements.txt \
+        -r /tmp/requirements-dev.txt \
+ && python -c "import pytest, pytest_asyncio, pytest_timeout, asyncua, websockets, dotenv, aiofiles, pytz; print('python deps OK')"
 
 # ---------------------------------------------------------------------------
 # 5. Bake npm cache from IJT Web Client package-lock + install Playwright

--- a/.github/docker/ijt-browser-ci/Dockerfile
+++ b/.github/docker/ijt-browser-ci/Dockerfile
@@ -14,7 +14,8 @@
 #     --user UID at runtime can read+write.
 #   - All base images are digest-pinned. Refresh procedure: re-pull tag,
 #     copy `Docker-Content-Digest` from the registry HEAD response, update
-#     both `FROM` lines and metadata.json `base_digests`.
+#     the Node, Python, and Ubuntu `FROM` lines and metadata.json
+#     `base_digests`.
 
 # ---------------------------------------------------------------------------
 # Stage 1: Node 24 source stage (digest-pinned).
@@ -23,12 +24,27 @@
 FROM node:24-bookworm-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS node
 
 # ---------------------------------------------------------------------------
-# Stage 2: Python 3.14 final image (digest-pinned).
+# Stage 2: Python 3.14 source stage (digest-pinned).
 #   python:3.14-slim-bookworm - manifest-list HEAD digest captured 2026-05-13.
+#   Used only as a donor of /usr/local (interpreter, stdlib, pip). The runtime
+#   final stage is Ubuntu Noble so the image's glibc matches the IJT Linux
+#   simulator binary requirement (GLIBC_2.38). CPython is forward-compatible
+#   across glibc versions, so a binary linked on bookworm (glibc 2.36) runs on
+#   Noble (glibc 2.39).
 # ---------------------------------------------------------------------------
-FROM python:3.14-slim-bookworm@sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec
+FROM python:3.14-slim-bookworm@sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec AS python
+
+# ---------------------------------------------------------------------------
+# Stage 3: Ubuntu 24.04 Noble final image (digest-pinned).
+#   ubuntu:24.04 - manifest-list HEAD digest captured 2026-05-13.
+#   Noble ships glibc 2.39 (the simulator binary needs GLIBC_2.38). Bookworm's
+#   glibc 2.36 is too old. Python 3.14 is copied from the official python
+#   stage above (no third-party PPA, no source build).
+# ---------------------------------------------------------------------------
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
     HOME=/opt/ijt-browser-ci/home \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
     npm_config_cache=/opt/ijt-browser-ci/npm-cache \
@@ -36,19 +52,37 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse
 
 # ---------------------------------------------------------------------------
-# 1. System tooling. build-essential covers any sdists that lack pre-built
-#    3.14 wheels; libs that are not part of `playwright install --with-deps`
-#    are intentionally omitted.
+# 1. Install Noble runtime tooling + the shared libraries Python 3.14 needs
+#    at runtime. Pulling `python3` as a meta-package brings in the canonical
+#    libssl3/libffi8/libsqlite3/etc. set with Noble's correct package names
+#    (including the libt64 transition variants); the copied CPython 3.14
+#    binary links against the same SONAMEs.
+#    build-essential covers any sdists that lack pre-built 3.14 wheels.
 # ---------------------------------------------------------------------------
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
+        python3 \
         build-essential pkg-config \
         git unzip \
  && rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------
-# 2. Copy Node 24 + npm + npx from the pinned node:24-bookworm-slim stage.
+# 2. Copy Python 3.14 (interpreter, stdlib, pip) from the digest-pinned
+#    official python:3.14-slim-bookworm stage. /usr/local/bin/python and
+#    /usr/local/bin/pip are created by that image; PATH puts /usr/local/bin
+#    first, so `python` resolves to 3.14, not Noble's bundled 3.12.
+# ---------------------------------------------------------------------------
+COPY --from=python /usr/local /usr/local
+RUN getconf GNU_LIBC_VERSION | grep -E '^glibc 2\.(3[89]|[4-9][0-9])' \
+ && python --version | grep -E '^Python 3\.14\.' \
+ && python -m pip --version \
+ && python -m venv /tmp/__venv-probe \
+ && /tmp/__venv-probe/bin/python -m pip --version \
+ && rm -rf /tmp/__venv-probe
+
+# ---------------------------------------------------------------------------
+# 3. Copy Node 24 + npm + npx from the pinned node:24-bookworm-slim stage.
 #    Avoids piping a remote setup script (supply-chain pin).
 #    Then assert the major matches v24.x (fail-fast in image build).
 # ---------------------------------------------------------------------------
@@ -57,11 +91,10 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
  && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
  && node --version | grep -E '^v24\.' \
- && npm --version \
- && python --version | grep -E '^Python 3\.14\.'
+ && npm --version
 
 # ---------------------------------------------------------------------------
-# 3. Pre-create cache dirs writable for any --user UID at runtime.
+# 4. Pre-create cache dirs writable for any --user UID at runtime.
 # ---------------------------------------------------------------------------
 RUN mkdir -p /opt/ijt-browser-ci/home \
              /opt/ijt-browser-ci/npm-cache \
@@ -73,7 +106,7 @@ RUN mkdir -p /opt/ijt-browser-ci/home \
  && chmod -R 0777 /opt/ijt-browser-ci /ms-playwright /workspace
 
 # ---------------------------------------------------------------------------
-# 4. Bake Python wheelhouse (complete closure, wheels only) from IJT Web
+# 5. Bake Python wheelhouse (complete closure, wheels only) from IJT Web
 #    Client requirements. PIP_FIND_LINKS at runtime points here, plus
 #    PIP_NO_INDEX=1, so the runtime venv-create + pip install is offline.
 # ---------------------------------------------------------------------------
@@ -92,7 +125,7 @@ RUN python -m pip install --upgrade pip \
  && python -c "import pytest, pytest_asyncio, pytest_timeout, asyncua, websockets, dotenv, aiofiles, pytz; print('python deps OK')"
 
 # ---------------------------------------------------------------------------
-# 5. Bake npm cache from IJT Web Client package-lock + install Playwright
+# 6. Bake npm cache from IJT Web Client package-lock + install Playwright
 #    Chromium and Linux system deps. The `--with-deps` apt cost happens HERE
 #    at image build, never in CI.
 # ---------------------------------------------------------------------------
@@ -104,7 +137,7 @@ RUN cd /opt/ijt-browser-ci/web-client-deps \
  && rm -rf /opt/ijt-browser-ci/web-client-deps/node_modules
 
 # ---------------------------------------------------------------------------
-# 6. Post-install permission fixup (build ran as root; runtime --user UID
+# 7. Post-install permission fixup (build ran as root; runtime --user UID
 #    must be able to read+write every cache path).
 # ---------------------------------------------------------------------------
 RUN chmod -R a+rwX /opt/ijt-browser-ci/npm-cache \
@@ -118,7 +151,7 @@ RUN chmod -R a+rwX /opt/ijt-browser-ci/npm-cache \
  && rm -rf /tmp/__venv-probe
 
 # ---------------------------------------------------------------------------
-# 7. Write metadata.json (durable image self-description for CI assertions).
+# 8. Write metadata.json (durable image self-description for CI assertions).
 # ---------------------------------------------------------------------------
 ARG IMAGE_BUILD_REF=unknown
 ARG IMAGE_BUILD_SHA=unknown
@@ -132,6 +165,7 @@ RUN python -c "import json,sys,subprocess; \
           'build_ref':'${IMAGE_BUILD_REF}','build_sha':'${IMAGE_BUILD_SHA}',\
           'build_created':'${IMAGE_BUILD_CREATED}',\
           'base_digests':{\
+            'ubuntu':'sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b',\
             'python':'sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec',\
             'node':'sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e'},\
           'cache_paths':{\
@@ -157,5 +191,6 @@ LABEL org.opencontainers.image.title="ijt-browser-ci" \
       org.umati.ijt.python_version="3.14" \
       org.umati.ijt.node_version="24.x" \
       org.umati.ijt.playwright_version="1.60.0" \
+      org.umati.ijt.base_ubuntu_digest="sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b" \
       org.umati.ijt.base_python_digest="sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec" \
       org.umati.ijt.base_node_digest="sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e"

--- a/.github/docker/ijt-browser-ci/Dockerfile
+++ b/.github/docker/ijt-browser-ci/Dockerfile
@@ -1,0 +1,155 @@
+# IJT Browser CI image
+#
+# Owned runtime image for the live-webclient-browser matrix job in
+# .github/workflows/integration.yml. Replaces live
+# `playwright install chromium --with-deps` on stock ubuntu-latest, which
+# is sensitive to upstream apt-mirror availability and timeout budgets.
+#
+# Contract:
+#   - Python 3.14.x, Node 24.x, Playwright 1.60.0 + Chromium + Linux system
+#     libs, all baked at image-build time.
+#   - Offline-by-construction at runtime: pip wheelhouse, npm cache, browser
+#     cache pre-warmed; intended to be invoked with --network=none.
+#   - Cache dirs under /opt/ijt-browser-ci are world-writable so non-root
+#     --user UID at runtime can read+write.
+#   - All base images are digest-pinned. Refresh procedure: re-pull tag,
+#     copy `Docker-Content-Digest` from the registry HEAD response, update
+#     both `FROM` lines and metadata.json `base_digests`.
+
+# ---------------------------------------------------------------------------
+# Stage 1: Node 24 source stage (digest-pinned).
+#   node:24-bookworm-slim - manifest-list HEAD digest captured 2026-05-13.
+# ---------------------------------------------------------------------------
+FROM node:24-bookworm-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS node
+
+# ---------------------------------------------------------------------------
+# Stage 2: Python 3.14 final image (digest-pinned).
+#   python:3.14-slim-bookworm - manifest-list HEAD digest captured 2026-05-13.
+# ---------------------------------------------------------------------------
+FROM python:3.14-slim-bookworm@sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/opt/ijt-browser-ci/home \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    npm_config_cache=/opt/ijt-browser-ci/npm-cache \
+    PIP_CACHE_DIR=/opt/ijt-browser-ci/pip-cache \
+    PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse
+
+# ---------------------------------------------------------------------------
+# 1. System tooling. build-essential covers any sdists that lack pre-built
+#    3.14 wheels; libs that are not part of `playwright install --with-deps`
+#    are intentionally omitted.
+# ---------------------------------------------------------------------------
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        build-essential pkg-config \
+        git unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# 2. Copy Node 24 + npm + npx from the pinned node:24-bookworm-slim stage.
+#    Avoids piping a remote setup script (supply-chain pin).
+#    Then assert the major matches v24.x (fail-fast in image build).
+# ---------------------------------------------------------------------------
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+ && node --version | grep -E '^v24\.' \
+ && npm --version \
+ && python --version | grep -E '^Python 3\.14\.'
+
+# ---------------------------------------------------------------------------
+# 3. Pre-create cache dirs writable for any --user UID at runtime.
+# ---------------------------------------------------------------------------
+RUN mkdir -p /opt/ijt-browser-ci/home \
+             /opt/ijt-browser-ci/npm-cache \
+             /opt/ijt-browser-ci/pip-cache \
+             /opt/ijt-browser-ci/pip-wheelhouse \
+             /opt/ijt-browser-ci/web-client-deps \
+             /ms-playwright \
+             /workspace \
+ && chmod -R 0777 /opt/ijt-browser-ci /ms-playwright /workspace
+
+# ---------------------------------------------------------------------------
+# 4. Bake Python wheelhouse (complete closure, wheels only) from IJT Web
+#    Client requirements. PIP_FIND_LINKS at runtime points here, plus
+#    PIP_NO_INDEX=1, so the runtime venv-create + pip install is offline.
+# ---------------------------------------------------------------------------
+COPY OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt /tmp/requirements.txt
+COPY OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt /tmp/requirements-dev.txt
+RUN python -m pip install --upgrade pip \
+ && python -m pip wheel --pre \
+        -r /tmp/requirements.txt \
+        -r /tmp/requirements-dev.txt \
+        --wheel-dir /opt/ijt-browser-ci/pip-wheelhouse
+
+# ---------------------------------------------------------------------------
+# 5. Bake npm cache from IJT Web Client package-lock + install Playwright
+#    Chromium and Linux system deps. The `--with-deps` apt cost happens HERE
+#    at image build, never in CI.
+# ---------------------------------------------------------------------------
+COPY OPC_UA_Clients/Release2/IJT_Web_Client/package.json /opt/ijt-browser-ci/web-client-deps/package.json
+COPY OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json /opt/ijt-browser-ci/web-client-deps/package-lock.json
+RUN cd /opt/ijt-browser-ci/web-client-deps \
+ && npm ci --legacy-peer-deps --no-audit --no-fund \
+ && npx playwright install --with-deps chromium \
+ && rm -rf /opt/ijt-browser-ci/web-client-deps/node_modules
+
+# ---------------------------------------------------------------------------
+# 6. Post-install permission fixup (build ran as root; runtime --user UID
+#    must be able to read+write every cache path).
+# ---------------------------------------------------------------------------
+RUN chmod -R a+rwX /opt/ijt-browser-ci/npm-cache \
+                    /opt/ijt-browser-ci/home \
+                    /opt/ijt-browser-ci/pip-cache \
+                    /opt/ijt-browser-ci/pip-wheelhouse \
+                    /ms-playwright \
+ && python --version | grep -E '^Python 3\.14\.' \
+ && python -m venv /tmp/__venv-probe \
+ && /tmp/__venv-probe/bin/python -m pip --version \
+ && rm -rf /tmp/__venv-probe
+
+# ---------------------------------------------------------------------------
+# 7. Write metadata.json (durable image self-description for CI assertions).
+# ---------------------------------------------------------------------------
+ARG IMAGE_BUILD_REF=unknown
+ARG IMAGE_BUILD_SHA=unknown
+ARG IMAGE_BUILD_CREATED=unknown
+RUN python -c "import json,sys,subprocess; \
+    py=sys.version.split()[0]; \
+    node=subprocess.check_output(['node','--version'],text=True).strip(); \
+    npm=subprocess.check_output(['npm','--version'],text=True).strip(); \
+    meta={'python_version':py,'node_version':node,'npm_version':npm,\
+          'playwright_version':'1.60.0',\
+          'build_ref':'${IMAGE_BUILD_REF}','build_sha':'${IMAGE_BUILD_SHA}',\
+          'build_created':'${IMAGE_BUILD_CREATED}',\
+          'base_digests':{\
+            'python':'sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec',\
+            'node':'sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e'},\
+          'cache_paths':{\
+            'pip_wheelhouse':'/opt/ijt-browser-ci/pip-wheelhouse',\
+            'pip_cache':'/opt/ijt-browser-ci/pip-cache',\
+            'npm_cache':'/opt/ijt-browser-ci/npm-cache',\
+            'playwright_browsers':'/ms-playwright',\
+            'home':'/opt/ijt-browser-ci/home'}}; \
+    open('/opt/ijt-browser-ci/metadata.json','w').write(json.dumps(meta,indent=2))" \
+ && chmod a+r /opt/ijt-browser-ci/metadata.json \
+ && cat /opt/ijt-browser-ci/metadata.json
+
+WORKDIR /workspace
+CMD ["bash"]
+
+LABEL org.opencontainers.image.title="ijt-browser-ci" \
+      org.opencontainers.image.description="Owned runtime image for IJT Web Client browser E2E suites." \
+      org.opencontainers.image.source="https://github.com/umati/UA-for-Industrial-Joining-Technologies" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.revision="${IMAGE_BUILD_SHA}" \
+      org.opencontainers.image.created="${IMAGE_BUILD_CREATED}" \
+      org.opencontainers.image.ref.name="${IMAGE_BUILD_REF}" \
+      org.umati.ijt.python_version="3.14" \
+      org.umati.ijt.node_version="24.x" \
+      org.umati.ijt.playwright_version="1.60.0" \
+      org.umati.ijt.base_python_digest="sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec" \
+      org.umati.ijt.base_node_digest="sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e"

--- a/.github/docker/ijt-browser-ci/README.md
+++ b/.github/docker/ijt-browser-ci/README.md
@@ -1,0 +1,34 @@
+# IJT Browser CI image
+
+Owned runtime image for the `live-webclient-browser` matrix job in
+`.github/workflows/integration.yml`. Replaces live `playwright install
+chromium --with-deps` on stock `ubuntu-latest`, which caused the
+apt-mirror-dependent failure observed in Integration run `25817063931` on
+commit `4ad418b5`.
+
+## Files
+
+- `Dockerfile` — image definition (Python 3.14, Node 24, Playwright 1.60.0
+  + Chromium + Linux system libs; wheelhouse + npm cache pre-warmed).
+
+## Image
+
+Published to `ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci`
+by `.github/workflows/build-browser-ci-image.yml`.
+
+## Runtime contract
+
+The image is consumed at runtime via a step-level `docker run` (NOT
+`jobs.<job>.container:`) in the `live-webclient-browser` matrix job. The
+container is invoked with:
+
+- `--network=none` — permanent offline contract; any silent live fetch fails.
+- `--user "$(id -u):$(id -g)"` — host runner UID for artifact ownership.
+- `-w /workspace` — repo root; the ROOT runner is invoked.
+- env: `HOME=/opt/ijt-browser-ci/home`, `npm_config_cache=...`,
+  `npm_config_offline=true`, `PIP_NO_INDEX=1`,
+  `PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse`,
+  `PIP_CACHE_DIR=...`, `SKIP_VENV_INSTALL=1`, plus the `GITHUB_*` whitelist.
+
+PR A (this PR) introduces only the image build and publish path. PR B will
+wire the image into `integration.yml`.

--- a/.github/workflows/build-browser-ci-image.yml
+++ b/.github/workflows/build-browser-ci-image.yml
@@ -111,15 +111,15 @@ jobs:
           set -euo pipefail
           IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
           docker run --rm --network=none "$IMG" cat /opt/ijt-browser-ci/metadata.json
-          docker run --rm --network=none "$IMG" sh -c 'python --version | grep -E "^Python 3\.14\."'
-          docker run --rm --network=none "$IMG" sh -c 'node --version | grep -E "^v24\."'
+          docker run --rm --network=none "$IMG" bash -c 'python --version | grep -E "^Python 3\.14\."'
+          docker run --rm --network=none "$IMG" bash -c 'node --version | grep -E "^v24\."'
 
       - name: Phase 0 smoke - cache & permissions probe (non-root UID)
         run: |
           set -euo pipefail
           IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
           UID_GID="$(id -u):$(id -g)"
-          docker run --rm --network=none --user "$UID_GID" "$IMG" sh -c '
+          docker run --rm --network=none --user "$UID_GID" "$IMG" bash -c '
             set -euo pipefail
             touch /opt/ijt-browser-ci/home/.probe
             touch /opt/ijt-browser-ci/npm-cache/.probe
@@ -271,8 +271,8 @@ jobs:
           echo "Pulling $REF ..."
           docker pull "$REF"
           docker run --rm --network=none "$REF" cat /opt/ijt-browser-ci/metadata.json
-          docker run --rm --network=none "$REF" sh -c 'python --version | grep -E "^Python 3\.14\."'
-          docker run --rm --network=none "$REF" sh -c 'node --version | grep -E "^v24\."'
+          docker run --rm --network=none "$REF" bash -c 'python --version | grep -E "^Python 3\.14\."'
+          docker run --rm --network=none "$REF" bash -c 'node --version | grep -E "^v24\."'
 
       - name: Job summary
         run: |

--- a/.github/workflows/build-browser-ci-image.yml
+++ b/.github/workflows/build-browser-ci-image.yml
@@ -1,0 +1,293 @@
+name: Build Browser CI Image
+
+# Build & publish the IJT Browser CI image consumed by the
+# live-webclient-browser matrix job in .github/workflows/integration.yml.
+# See .github/docker/ijt-browser-ci/README.md for design.
+#
+# PR A scope: build path only. PR B wires the image into integration.yml.
+#
+# Two-job split:
+#   - build:   loads image locally, runs Phase 0 smoke under the exact
+#              runtime contract. NO packages: write.
+#   - publish: depends on build; only runs when push == true; pushes to GHCR
+#              with packages: write scoped to this job only.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/docker/ijt-browser-ci/**'
+      - '.github/workflows/build-browser-ci-image.yml'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt'
+  pull_request:
+    paths:
+      - '.github/docker/ijt-browser-ci/**'
+      - '.github/workflows/build-browser-ci-image.yml'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt'
+  schedule:
+    - cron: '17 5 * * 1'  # weekly Monday 05:17 UTC
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push image to GHCR (true) or build-only (false)?'
+        required: false
+        default: 'false'
+        type: choice
+        options: [ 'true', 'false' ]
+
+# Workflow-level: read-only. packages: write is granted only on the publish
+# job below.
+permissions:
+  contents: read
+
+concurrency:
+  group: build-browser-ci-image-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci
+
+jobs:
+  build:
+    name: Build & Phase-0 smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    outputs:
+      should_push: ${{ steps.decide.outputs.push }}
+      short_sha: ${{ steps.decide.outputs.short_sha }}
+      cache_key: ${{ steps.decide.outputs.cache_key }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      - name: Decide whether to push (carry to publish job)
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          DISPATCH_PUSH: ${{ inputs.push }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "cache_key=ijt-browser-ci-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "push=${DISPATCH_PUSH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build image (load only, gha cache export)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
+        with:
+          context: .
+          file: .github/docker/ijt-browser-ci/Dockerfile
+          load: true
+          push: false
+          tags: ${{ env.IMAGE_NAME }}:phase0-${{ steps.decide.outputs.short_sha }}
+          build-args: |
+            IMAGE_BUILD_REF=${{ github.ref }}
+            IMAGE_BUILD_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=ijt-browser-ci
+          cache-to: type=gha,scope=ijt-browser-ci,mode=max
+
+      - name: Phase 0 smoke - metadata + tool versions
+        run: |
+          set -euo pipefail
+          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          docker run --rm --network=none "$IMG" cat /opt/ijt-browser-ci/metadata.json
+          docker run --rm --network=none "$IMG" sh -c 'python --version | grep -E "^Python 3\.14\."'
+          docker run --rm --network=none "$IMG" sh -c 'node --version | grep -E "^v24\."'
+
+      - name: Phase 0 smoke - cache & permissions probe (non-root UID)
+        run: |
+          set -euo pipefail
+          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          UID_GID="$(id -u):$(id -g)"
+          docker run --rm --network=none --user "$UID_GID" "$IMG" sh -c '
+            set -euo pipefail
+            touch /opt/ijt-browser-ci/home/.probe
+            touch /opt/ijt-browser-ci/npm-cache/.probe
+            touch /opt/ijt-browser-ci/pip-cache/.probe
+            ls /opt/ijt-browser-ci/pip-wheelhouse | head -5
+            ls /ms-playwright | head -5
+            python -m venv /tmp/v && /tmp/v/bin/python -m pip --version
+          '
+
+      - name: Phase 0 smoke - root runner under --network=none (web-client-e2e-regression)
+        # This is the production contract: repo root, root runner, full
+        # offline env, host UID. Any silent live fetch or contract violation
+        # fails this step and PR A. Artifacts are captured for inspection
+        # regardless of pass/fail via the always() upload step below.
+        id: deep_smoke
+        run: |
+          set -euo pipefail
+          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          UID_GID="$(id -u):$(id -g)"
+          mkdir -p "${GITHUB_WORKSPACE}/.phase0-artifacts"
+          chmod 0777 "${GITHUB_WORKSPACE}/.phase0-artifacts"
+          docker run --rm \
+            --network=none \
+            --user "$UID_GID" \
+            -w /workspace \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -e HOME=/opt/ijt-browser-ci/home \
+            -e CI=1 \
+            -e npm_config_cache=/opt/ijt-browser-ci/npm-cache \
+            -e npm_config_offline=true \
+            -e PIP_CACHE_DIR=/opt/ijt-browser-ci/pip-cache \
+            -e PIP_NO_INDEX=1 \
+            -e PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse \
+            -e SKIP_VENV_INSTALL=1 \
+            -e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+            "$IMG" \
+            bash -lc 'python run_all_tests.py --suite web-client-e2e-regression --verbose'
+
+      - name: Stage Phase 0 artifacts
+        if: always()
+        run: |
+          set -euxo pipefail
+          mkdir -p "${GITHUB_WORKSPACE}/.phase0-artifacts"
+          for src in \
+            "${GITHUB_WORKSPACE}/OPC_UA_Clients/Release2/IJT_Web_Client/test-results" \
+            "${GITHUB_WORKSPACE}/test-results"; do
+            if [[ -d "$src" ]]; then
+              dest="${GITHUB_WORKSPACE}/.phase0-artifacts/$(basename "$(dirname "$src")")-$(basename "$src")"
+              cp -r "$src" "$dest" || true
+            fi
+          done
+          ls -la "${GITHUB_WORKSPACE}/.phase0-artifacts" || true
+
+      - name: Upload Phase 0 artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: phase0-${{ steps.decide.outputs.short_sha }}
+          path: |
+            .phase0-artifacts/**
+            OPC_UA_Clients/Release2/IJT_Web_Client/test-results/**
+            test-results/**
+          if-no-files-found: ignore
+
+      - name: Job summary
+        if: always()
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
+          WILL_PUBLISH: ${{ steps.decide.outputs.push }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## IJT Browser CI image - Phase 0 build"
+            echo ""
+            echo "- Event: \`${EVENT_NAME}\`"
+            echo "- Ref: \`${REF}\`"
+            echo "- Short SHA: \`${SHORT_SHA}\`"
+            echo "- Will publish: \`${WILL_PUBLISH}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish to GHCR
+    needs: build
+    if: needs.build.outputs.should_push == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute publish tags
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          BUILD_SHORT_SHA: ${{ needs.build.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          TAGS="${IMAGE_NAME}:sha-${BUILD_SHORT_SHA}"
+          if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE_NAME}:main"
+          fi
+          {
+            echo 'tags<<EOF'
+            echo "$TAGS"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Push image (cache from build job)
+        id: push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
+        with:
+          context: .
+          file: .github/docker/ijt-browser-ci/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            IMAGE_BUILD_REF=${{ github.ref }}
+            IMAGE_BUILD_SHA=${{ github.sha }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=ijt-browser-ci
+
+      - name: Verify published image by digest (pull + offline smoke)
+        # Proves GHCR pull permission AND that the digest is usable as
+        # IJT_BROWSER_CI_IMAGE for PR B. Hard gate.
+        run: |
+          set -euo pipefail
+          REF="${IMAGE_NAME}@${{ steps.push.outputs.digest }}"
+          echo "Pulling $REF ..."
+          docker pull "$REF"
+          docker run --rm --network=none "$REF" cat /opt/ijt-browser-ci/metadata.json
+          docker run --rm --network=none "$REF" sh -c 'python --version | grep -E "^Python 3\.14\."'
+          docker run --rm --network=none "$REF" sh -c 'node --version | grep -E "^v24\."'
+
+      - name: Job summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## IJT Browser CI image - Published"
+            echo ""
+            echo "- Tags:"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo "- Digest: \`${{ steps.push.outputs.digest }}\`"
+            echo ""
+            echo "_PR B can pin (paste into \`integration.yml\` or \`image-pin.json\`):_"
+            echo '```'
+            echo "${IMAGE_NAME}@${{ steps.push.outputs.digest }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
1. Add Dockerfile that pre-bakes Python 3.14, Node 24, Playwright 1.60.0, Chromium, and Linux system libs so browser jobs do not run live apt installs in CI.
2. Pin both base images by digest and copy Node from the pinned Node stage instead of curl-to-shell installer.
3. Bake pip wheelhouse and warm npm cache into the image so runtime can run with --network=none.
4. Write metadata.json inside the image with tool versions, base digests, and cache paths for runtime drift checks.
5. Add build workflow split into a read-only build job and a publish job that alone has GHCR write permission.
6. Keep integration.yml unchanged in PR A; PR B will pin the published digest after PR A proves the image path.