### PR TITLE
Run Browser E2E Through the Owned CI Image

### DIFF
--- a/.github/docker/ijt-browser-ci/Dockerfile
+++ b/.github/docker/ijt-browser-ci/Dockerfile
@@ -83,7 +83,13 @@ RUN python -m pip install --upgrade pip \
  && python -m pip wheel --pre \
         -r /tmp/requirements.txt \
         -r /tmp/requirements-dev.txt \
-        --wheel-dir /opt/ijt-browser-ci/pip-wheelhouse
+        --wheel-dir /opt/ijt-browser-ci/pip-wheelhouse \
+ && python -m pip install --pre \
+        --no-index \
+        --find-links /opt/ijt-browser-ci/pip-wheelhouse \
+        -r /tmp/requirements.txt \
+        -r /tmp/requirements-dev.txt \
+ && python -c "import pytest, pytest_asyncio, pytest_timeout, asyncua, websockets, dotenv, aiofiles, pytz; print('python deps OK')"
 
 # ---------------------------------------------------------------------------
 # 5. Bake npm cache from IJT Web Client package-lock + install Playwright

--- a/.github/docker/ijt-browser-ci/Dockerfile
+++ b/.github/docker/ijt-browser-ci/Dockerfile
@@ -14,7 +14,8 @@
 #     --user UID at runtime can read+write.
 #   - All base images are digest-pinned. Refresh procedure: re-pull tag,
 #     copy `Docker-Content-Digest` from the registry HEAD response, update
-#     both `FROM` lines and metadata.json `base_digests`.
+#     the Node, Python, and Ubuntu `FROM` lines and metadata.json
+#     `base_digests`.
 
 # ---------------------------------------------------------------------------
 # Stage 1: Node 24 source stage (digest-pinned).
@@ -23,12 +24,27 @@
 FROM node:24-bookworm-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS node
 
 # ---------------------------------------------------------------------------
-# Stage 2: Python 3.14 final image (digest-pinned).
+# Stage 2: Python 3.14 source stage (digest-pinned).
 #   python:3.14-slim-bookworm - manifest-list HEAD digest captured 2026-05-13.
+#   Used only as a donor of /usr/local (interpreter, stdlib, pip). The runtime
+#   final stage is Ubuntu Noble so the image's glibc matches the IJT Linux
+#   simulator binary requirement (GLIBC_2.38). CPython is forward-compatible
+#   across glibc versions, so a binary linked on bookworm (glibc 2.36) runs on
+#   Noble (glibc 2.39).
 # ---------------------------------------------------------------------------
-FROM python:3.14-slim-bookworm@sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec
+FROM python:3.14-slim-bookworm@sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec AS python
+
+# ---------------------------------------------------------------------------
+# Stage 3: Ubuntu 24.04 Noble final image (digest-pinned).
+#   ubuntu:24.04 - manifest-list HEAD digest captured 2026-05-13.
+#   Noble ships glibc 2.39 (the simulator binary needs GLIBC_2.38). Bookworm's
+#   glibc 2.36 is too old. Python 3.14 is copied from the official python
+#   stage above (no third-party PPA, no source build).
+# ---------------------------------------------------------------------------
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
     HOME=/opt/ijt-browser-ci/home \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
     npm_config_cache=/opt/ijt-browser-ci/npm-cache \
@@ -36,19 +52,37 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse
 
 # ---------------------------------------------------------------------------
-# 1. System tooling. build-essential covers any sdists that lack pre-built
-#    3.14 wheels; libs that are not part of `playwright install --with-deps`
-#    are intentionally omitted.
+# 1. Install Noble runtime tooling + the shared libraries Python 3.14 needs
+#    at runtime. Pulling `python3` as a meta-package brings in the canonical
+#    libssl3/libffi8/libsqlite3/etc. set with Noble's correct package names
+#    (including the libt64 transition variants); the copied CPython 3.14
+#    binary links against the same SONAMEs.
+#    build-essential covers any sdists that lack pre-built 3.14 wheels.
 # ---------------------------------------------------------------------------
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
+        python3 \
         build-essential pkg-config \
         git unzip \
  && rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------
-# 2. Copy Node 24 + npm + npx from the pinned node:24-bookworm-slim stage.
+# 2. Copy Python 3.14 (interpreter, stdlib, pip) from the digest-pinned
+#    official python:3.14-slim-bookworm stage. /usr/local/bin/python and
+#    /usr/local/bin/pip are created by that image; PATH puts /usr/local/bin
+#    first, so `python` resolves to 3.14, not Noble's bundled 3.12.
+# ---------------------------------------------------------------------------
+COPY --from=python /usr/local /usr/local
+RUN getconf GNU_LIBC_VERSION | grep -E '^glibc 2\.(3[89]|[4-9][0-9])' \
+ && python --version | grep -E '^Python 3\.14\.' \
+ && python -m pip --version \
+ && python -m venv /tmp/__venv-probe \
+ && /tmp/__venv-probe/bin/python -m pip --version \
+ && rm -rf /tmp/__venv-probe
+
+# ---------------------------------------------------------------------------
+# 3. Copy Node 24 + npm + npx from the pinned node:24-bookworm-slim stage.
 #    Avoids piping a remote setup script (supply-chain pin).
 #    Then assert the major matches v24.x (fail-fast in image build).
 # ---------------------------------------------------------------------------
@@ -57,11 +91,10 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
  && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
  && node --version | grep -E '^v24\.' \
- && npm --version \
- && python --version | grep -E '^Python 3\.14\.'
+ && npm --version
 
 # ---------------------------------------------------------------------------
-# 3. Pre-create cache dirs writable for any --user UID at runtime.
+# 4. Pre-create cache dirs writable for any --user UID at runtime.
 # ---------------------------------------------------------------------------
 RUN mkdir -p /opt/ijt-browser-ci/home \
              /opt/ijt-browser-ci/npm-cache \
@@ -73,7 +106,7 @@ RUN mkdir -p /opt/ijt-browser-ci/home \
  && chmod -R 0777 /opt/ijt-browser-ci /ms-playwright /workspace
 
 # ---------------------------------------------------------------------------
-# 4. Bake Python wheelhouse (complete closure, wheels only) from IJT Web
+# 5. Bake Python wheelhouse (complete closure, wheels only) from IJT Web
 #    Client requirements. PIP_FIND_LINKS at runtime points here, plus
 #    PIP_NO_INDEX=1, so the runtime venv-create + pip install is offline.
 # ---------------------------------------------------------------------------
@@ -92,7 +125,7 @@ RUN python -m pip install --upgrade pip \
  && python -c "import pytest, pytest_asyncio, pytest_timeout, asyncua, websockets, dotenv, aiofiles, pytz; print('python deps OK')"
 
 # ---------------------------------------------------------------------------
-# 5. Bake npm cache from IJT Web Client package-lock + install Playwright
+# 6. Bake npm cache from IJT Web Client package-lock + install Playwright
 #    Chromium and Linux system deps. The `--with-deps` apt cost happens HERE
 #    at image build, never in CI.
 # ---------------------------------------------------------------------------
@@ -104,7 +137,7 @@ RUN cd /opt/ijt-browser-ci/web-client-deps \
  && rm -rf /opt/ijt-browser-ci/web-client-deps/node_modules
 
 # ---------------------------------------------------------------------------
-# 6. Post-install permission fixup (build ran as root; runtime --user UID
+# 7. Post-install permission fixup (build ran as root; runtime --user UID
 #    must be able to read+write every cache path).
 # ---------------------------------------------------------------------------
 RUN chmod -R a+rwX /opt/ijt-browser-ci/npm-cache \
@@ -118,7 +151,7 @@ RUN chmod -R a+rwX /opt/ijt-browser-ci/npm-cache \
  && rm -rf /tmp/__venv-probe
 
 # ---------------------------------------------------------------------------
-# 7. Write metadata.json (durable image self-description for CI assertions).
+# 8. Write metadata.json (durable image self-description for CI assertions).
 # ---------------------------------------------------------------------------
 ARG IMAGE_BUILD_REF=unknown
 ARG IMAGE_BUILD_SHA=unknown
@@ -132,6 +165,7 @@ RUN python -c "import json,sys,subprocess; \
           'build_ref':'${IMAGE_BUILD_REF}','build_sha':'${IMAGE_BUILD_SHA}',\
           'build_created':'${IMAGE_BUILD_CREATED}',\
           'base_digests':{\
+            'ubuntu':'sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b',\
             'python':'sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec',\
             'node':'sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e'},\
           'cache_paths':{\
@@ -157,5 +191,6 @@ LABEL org.opencontainers.image.title="ijt-browser-ci" \
       org.umati.ijt.python_version="3.14" \
       org.umati.ijt.node_version="24.x" \
       org.umati.ijt.playwright_version="1.60.0" \
+      org.umati.ijt.base_ubuntu_digest="sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b" \
       org.umati.ijt.base_python_digest="sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec" \
       org.umati.ijt.base_node_digest="sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e"

--- a/.github/docker/ijt-browser-ci/Dockerfile
+++ b/.github/docker/ijt-browser-ci/Dockerfile
@@ -1,0 +1,155 @@
+# IJT Browser CI image
+#
+# Owned runtime image for the live-webclient-browser matrix job in
+# .github/workflows/integration.yml. Replaces live
+# `playwright install chromium --with-deps` on stock ubuntu-latest, which
+# is sensitive to upstream apt-mirror availability and timeout budgets.
+#
+# Contract:
+#   - Python 3.14.x, Node 24.x, Playwright 1.60.0 + Chromium + Linux system
+#     libs, all baked at image-build time.
+#   - Offline-by-construction at runtime: pip wheelhouse, npm cache, browser
+#     cache pre-warmed; intended to be invoked with --network=none.
+#   - Cache dirs under /opt/ijt-browser-ci are world-writable so non-root
+#     --user UID at runtime can read+write.
+#   - All base images are digest-pinned. Refresh procedure: re-pull tag,
+#     copy `Docker-Content-Digest` from the registry HEAD response, update
+#     both `FROM` lines and metadata.json `base_digests`.
+
+# ---------------------------------------------------------------------------
+# Stage 1: Node 24 source stage (digest-pinned).
+#   node:24-bookworm-slim - manifest-list HEAD digest captured 2026-05-13.
+# ---------------------------------------------------------------------------
+FROM node:24-bookworm-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS node
+
+# ---------------------------------------------------------------------------
+# Stage 2: Python 3.14 final image (digest-pinned).
+#   python:3.14-slim-bookworm - manifest-list HEAD digest captured 2026-05-13.
+# ---------------------------------------------------------------------------
+FROM python:3.14-slim-bookworm@sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/opt/ijt-browser-ci/home \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    npm_config_cache=/opt/ijt-browser-ci/npm-cache \
+    PIP_CACHE_DIR=/opt/ijt-browser-ci/pip-cache \
+    PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse
+
+# ---------------------------------------------------------------------------
+# 1. System tooling. build-essential covers any sdists that lack pre-built
+#    3.14 wheels; libs that are not part of `playwright install --with-deps`
+#    are intentionally omitted.
+# ---------------------------------------------------------------------------
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        build-essential pkg-config \
+        git unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# 2. Copy Node 24 + npm + npx from the pinned node:24-bookworm-slim stage.
+#    Avoids piping a remote setup script (supply-chain pin).
+#    Then assert the major matches v24.x (fail-fast in image build).
+# ---------------------------------------------------------------------------
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+ && node --version | grep -E '^v24\.' \
+ && npm --version \
+ && python --version | grep -E '^Python 3\.14\.'
+
+# ---------------------------------------------------------------------------
+# 3. Pre-create cache dirs writable for any --user UID at runtime.
+# ---------------------------------------------------------------------------
+RUN mkdir -p /opt/ijt-browser-ci/home \
+             /opt/ijt-browser-ci/npm-cache \
+             /opt/ijt-browser-ci/pip-cache \
+             /opt/ijt-browser-ci/pip-wheelhouse \
+             /opt/ijt-browser-ci/web-client-deps \
+             /ms-playwright \
+             /workspace \
+ && chmod -R 0777 /opt/ijt-browser-ci /ms-playwright /workspace
+
+# ---------------------------------------------------------------------------
+# 4. Bake Python wheelhouse (complete closure, wheels only) from IJT Web
+#    Client requirements. PIP_FIND_LINKS at runtime points here, plus
+#    PIP_NO_INDEX=1, so the runtime venv-create + pip install is offline.
+# ---------------------------------------------------------------------------
+COPY OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt /tmp/requirements.txt
+COPY OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt /tmp/requirements-dev.txt
+RUN python -m pip install --upgrade pip \
+ && python -m pip wheel --pre \
+        -r /tmp/requirements.txt \
+        -r /tmp/requirements-dev.txt \
+        --wheel-dir /opt/ijt-browser-ci/pip-wheelhouse
+
+# ---------------------------------------------------------------------------
+# 5. Bake npm cache from IJT Web Client package-lock + install Playwright
+#    Chromium and Linux system deps. The `--with-deps` apt cost happens HERE
+#    at image build, never in CI.
+# ---------------------------------------------------------------------------
+COPY OPC_UA_Clients/Release2/IJT_Web_Client/package.json /opt/ijt-browser-ci/web-client-deps/package.json
+COPY OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json /opt/ijt-browser-ci/web-client-deps/package-lock.json
+RUN cd /opt/ijt-browser-ci/web-client-deps \
+ && npm ci --legacy-peer-deps --no-audit --no-fund \
+ && npx playwright install --with-deps chromium \
+ && rm -rf /opt/ijt-browser-ci/web-client-deps/node_modules
+
+# ---------------------------------------------------------------------------
+# 6. Post-install permission fixup (build ran as root; runtime --user UID
+#    must be able to read+write every cache path).
+# ---------------------------------------------------------------------------
+RUN chmod -R a+rwX /opt/ijt-browser-ci/npm-cache \
+                    /opt/ijt-browser-ci/home \
+                    /opt/ijt-browser-ci/pip-cache \
+                    /opt/ijt-browser-ci/pip-wheelhouse \
+                    /ms-playwright \
+ && python --version | grep -E '^Python 3\.14\.' \
+ && python -m venv /tmp/__venv-probe \
+ && /tmp/__venv-probe/bin/python -m pip --version \
+ && rm -rf /tmp/__venv-probe
+
+# ---------------------------------------------------------------------------
+# 7. Write metadata.json (durable image self-description for CI assertions).
+# ---------------------------------------------------------------------------
+ARG IMAGE_BUILD_REF=unknown
+ARG IMAGE_BUILD_SHA=unknown
+ARG IMAGE_BUILD_CREATED=unknown
+RUN python -c "import json,sys,subprocess; \
+    py=sys.version.split()[0]; \
+    node=subprocess.check_output(['node','--version'],text=True).strip(); \
+    npm=subprocess.check_output(['npm','--version'],text=True).strip(); \
+    meta={'python_version':py,'node_version':node,'npm_version':npm,\
+          'playwright_version':'1.60.0',\
+          'build_ref':'${IMAGE_BUILD_REF}','build_sha':'${IMAGE_BUILD_SHA}',\
+          'build_created':'${IMAGE_BUILD_CREATED}',\
+          'base_digests':{\
+            'python':'sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec',\
+            'node':'sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e'},\
+          'cache_paths':{\
+            'pip_wheelhouse':'/opt/ijt-browser-ci/pip-wheelhouse',\
+            'pip_cache':'/opt/ijt-browser-ci/pip-cache',\
+            'npm_cache':'/opt/ijt-browser-ci/npm-cache',\
+            'playwright_browsers':'/ms-playwright',\
+            'home':'/opt/ijt-browser-ci/home'}}; \
+    open('/opt/ijt-browser-ci/metadata.json','w').write(json.dumps(meta,indent=2))" \
+ && chmod a+r /opt/ijt-browser-ci/metadata.json \
+ && cat /opt/ijt-browser-ci/metadata.json
+
+WORKDIR /workspace
+CMD ["bash"]
+
+LABEL org.opencontainers.image.title="ijt-browser-ci" \
+      org.opencontainers.image.description="Owned runtime image for IJT Web Client browser E2E suites." \
+      org.opencontainers.image.source="https://github.com/umati/UA-for-Industrial-Joining-Technologies" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.revision="${IMAGE_BUILD_SHA}" \
+      org.opencontainers.image.created="${IMAGE_BUILD_CREATED}" \
+      org.opencontainers.image.ref.name="${IMAGE_BUILD_REF}" \
+      org.umati.ijt.python_version="3.14" \
+      org.umati.ijt.node_version="24.x" \
+      org.umati.ijt.playwright_version="1.60.0" \
+      org.umati.ijt.base_python_digest="sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec" \
+      org.umati.ijt.base_node_digest="sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e"

--- a/.github/docker/ijt-browser-ci/README.md
+++ b/.github/docker/ijt-browser-ci/README.md
@@ -1,0 +1,34 @@
+# IJT Browser CI image
+
+Owned runtime image for the `live-webclient-browser` matrix job in
+`.github/workflows/integration.yml`. Replaces live `playwright install
+chromium --with-deps` on stock `ubuntu-latest`, which caused the
+apt-mirror-dependent failure observed in Integration run `25817063931` on
+commit `4ad418b5`.
+
+## Files
+
+- `Dockerfile` — image definition (Python 3.14, Node 24, Playwright 1.60.0
+  + Chromium + Linux system libs; wheelhouse + npm cache pre-warmed).
+
+## Image
+
+Published to `ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci`
+by `.github/workflows/build-browser-ci-image.yml`.
+
+## Runtime contract
+
+The image is consumed at runtime via a step-level `docker run` (NOT
+`jobs.<job>.container:`) in the `live-webclient-browser` matrix job. The
+container is invoked with:
+
+- `--network=none` — permanent offline contract; any silent live fetch fails.
+- `--user "$(id -u):$(id -g)"` — host runner UID for artifact ownership.
+- `-w /workspace` — repo root; the ROOT runner is invoked.
+- env: `HOME=/opt/ijt-browser-ci/home`, `npm_config_cache=...`,
+  `npm_config_offline=true`, `PIP_NO_INDEX=1`,
+  `PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse`,
+  `PIP_CACHE_DIR=...`, `SKIP_VENV_INSTALL=1`, plus the `GITHUB_*` whitelist.
+
+PR A (this PR) introduces only the image build and publish path. PR B will
+wire the image into `integration.yml`.

--- a/.github/docker/ijt-browser-ci/image-pin.json
+++ b/.github/docker/ijt-browser-ci/image-pin.json
@@ -1,0 +1,11 @@
+{
+  "image": "ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci",
+  "digest": "sha256:b94c883d9d89777502ce3a9a43d4414b4a97d39b752631c6c609f36771cda3ba",
+  "playwright_version": "1.60.0",
+  "node_version": "24.x",
+  "python_version": "3.14.x",
+  "image_revision": "3768a248",
+  "image_created": "2026-05-13T20:39:23Z",
+  "image_workflow_run": "https://github.com/umati/UA-for-Industrial-Joining-Technologies/actions/runs/25824684520",
+  "_comment": "Single source of truth for the IJT Browser CI image consumed by integration.yml live-webclient-browser. IJT_BROWSER_CI_IMAGE is constructed at runtime as image@digest. Refresh procedure: when a new image is published, copy the digest from the Publish to GHCR job summary into this file. The workflow MUST fail fast if digest does not match ^sha256:[0-9a-f]{64}$."
+}

--- a/.github/workflows/build-browser-ci-image.yml
+++ b/.github/workflows/build-browser-ci-image.yml
@@ -111,15 +111,15 @@ jobs:
           set -euo pipefail
           IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
           docker run --rm --network=none "$IMG" cat /opt/ijt-browser-ci/metadata.json
-          docker run --rm --network=none "$IMG" sh -c 'python --version | grep -E "^Python 3\.14\."'
-          docker run --rm --network=none "$IMG" sh -c 'node --version | grep -E "^v24\."'
+          docker run --rm --network=none "$IMG" bash -c 'python --version | grep -E "^Python 3\.14\."'
+          docker run --rm --network=none "$IMG" bash -c 'node --version | grep -E "^v24\."'
 
       - name: Phase 0 smoke - cache & permissions probe (non-root UID)
         run: |
           set -euo pipefail
           IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
           UID_GID="$(id -u):$(id -g)"
-          docker run --rm --network=none --user "$UID_GID" "$IMG" sh -c '
+          docker run --rm --network=none --user "$UID_GID" "$IMG" bash -c '
             set -euo pipefail
             touch /opt/ijt-browser-ci/home/.probe
             touch /opt/ijt-browser-ci/npm-cache/.probe
@@ -271,8 +271,8 @@ jobs:
           echo "Pulling $REF ..."
           docker pull "$REF"
           docker run --rm --network=none "$REF" cat /opt/ijt-browser-ci/metadata.json
-          docker run --rm --network=none "$REF" sh -c 'python --version | grep -E "^Python 3\.14\."'
-          docker run --rm --network=none "$REF" sh -c 'node --version | grep -E "^v24\."'
+          docker run --rm --network=none "$REF" bash -c 'python --version | grep -E "^Python 3\.14\."'
+          docker run --rm --network=none "$REF" bash -c 'node --version | grep -E "^v24\."'
 
       - name: Job summary
         run: |

--- a/.github/workflows/build-browser-ci-image.yml
+++ b/.github/workflows/build-browser-ci-image.yml
@@ -1,0 +1,293 @@
+name: Build Browser CI Image
+
+# Build & publish the IJT Browser CI image consumed by the
+# live-webclient-browser matrix job in .github/workflows/integration.yml.
+# See .github/docker/ijt-browser-ci/README.md for design.
+#
+# PR A scope: build path only. PR B wires the image into integration.yml.
+#
+# Two-job split:
+#   - build:   loads image locally, runs Phase 0 smoke under the exact
+#              runtime contract. NO packages: write.
+#   - publish: depends on build; only runs when push == true; pushes to GHCR
+#              with packages: write scoped to this job only.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/docker/ijt-browser-ci/**'
+      - '.github/workflows/build-browser-ci-image.yml'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt'
+  pull_request:
+    paths:
+      - '.github/docker/ijt-browser-ci/**'
+      - '.github/workflows/build-browser-ci-image.yml'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt'
+      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt'
+  schedule:
+    - cron: '17 5 * * 1'  # weekly Monday 05:17 UTC
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push image to GHCR (true) or build-only (false)?'
+        required: false
+        default: 'false'
+        type: choice
+        options: [ 'true', 'false' ]
+
+# Workflow-level: read-only. packages: write is granted only on the publish
+# job below.
+permissions:
+  contents: read
+
+concurrency:
+  group: build-browser-ci-image-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci
+
+jobs:
+  build:
+    name: Build & Phase-0 smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    outputs:
+      should_push: ${{ steps.decide.outputs.push }}
+      short_sha: ${{ steps.decide.outputs.short_sha }}
+      cache_key: ${{ steps.decide.outputs.cache_key }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      - name: Decide whether to push (carry to publish job)
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          DISPATCH_PUSH: ${{ inputs.push }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "cache_key=ijt-browser-ci-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "push=${DISPATCH_PUSH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build image (load only, gha cache export)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
+        with:
+          context: .
+          file: .github/docker/ijt-browser-ci/Dockerfile
+          load: true
+          push: false
+          tags: ${{ env.IMAGE_NAME }}:phase0-${{ steps.decide.outputs.short_sha }}
+          build-args: |
+            IMAGE_BUILD_REF=${{ github.ref }}
+            IMAGE_BUILD_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=ijt-browser-ci
+          cache-to: type=gha,scope=ijt-browser-ci,mode=max
+
+      - name: Phase 0 smoke - metadata + tool versions
+        run: |
+          set -euo pipefail
+          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          docker run --rm --network=none "$IMG" cat /opt/ijt-browser-ci/metadata.json
+          docker run --rm --network=none "$IMG" sh -c 'python --version | grep -E "^Python 3\.14\."'
+          docker run --rm --network=none "$IMG" sh -c 'node --version | grep -E "^v24\."'
+
+      - name: Phase 0 smoke - cache & permissions probe (non-root UID)
+        run: |
+          set -euo pipefail
+          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          UID_GID="$(id -u):$(id -g)"
+          docker run --rm --network=none --user "$UID_GID" "$IMG" sh -c '
+            set -euo pipefail
+            touch /opt/ijt-browser-ci/home/.probe
+            touch /opt/ijt-browser-ci/npm-cache/.probe
+            touch /opt/ijt-browser-ci/pip-cache/.probe
+            ls /opt/ijt-browser-ci/pip-wheelhouse | head -5
+            ls /ms-playwright | head -5
+            python -m venv /tmp/v && /tmp/v/bin/python -m pip --version
+          '
+
+      - name: Phase 0 smoke - root runner under --network=none (web-client-e2e-regression)
+        # This is the production contract: repo root, root runner, full
+        # offline env, host UID. Any silent live fetch or contract violation
+        # fails this step and PR A. Artifacts are captured for inspection
+        # regardless of pass/fail via the always() upload step below.
+        id: deep_smoke
+        run: |
+          set -euo pipefail
+          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          UID_GID="$(id -u):$(id -g)"
+          mkdir -p "${GITHUB_WORKSPACE}/.phase0-artifacts"
+          chmod 0777 "${GITHUB_WORKSPACE}/.phase0-artifacts"
+          docker run --rm \
+            --network=none \
+            --user "$UID_GID" \
+            -w /workspace \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -e HOME=/opt/ijt-browser-ci/home \
+            -e CI=1 \
+            -e npm_config_cache=/opt/ijt-browser-ci/npm-cache \
+            -e npm_config_offline=true \
+            -e PIP_CACHE_DIR=/opt/ijt-browser-ci/pip-cache \
+            -e PIP_NO_INDEX=1 \
+            -e PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse \
+            -e SKIP_VENV_INSTALL=1 \
+            -e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+            "$IMG" \
+            bash -lc 'python run_all_tests.py --suite web-client-e2e-regression --verbose'
+
+      - name: Stage Phase 0 artifacts
+        if: always()
+        run: |
+          set -euxo pipefail
+          mkdir -p "${GITHUB_WORKSPACE}/.phase0-artifacts"
+          for src in \
+            "${GITHUB_WORKSPACE}/OPC_UA_Clients/Release2/IJT_Web_Client/test-results" \
+            "${GITHUB_WORKSPACE}/test-results"; do
+            if [[ -d "$src" ]]; then
+              dest="${GITHUB_WORKSPACE}/.phase0-artifacts/$(basename "$(dirname "$src")")-$(basename "$src")"
+              cp -r "$src" "$dest" || true
+            fi
+          done
+          ls -la "${GITHUB_WORKSPACE}/.phase0-artifacts" || true
+
+      - name: Upload Phase 0 artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: phase0-${{ steps.decide.outputs.short_sha }}
+          path: |
+            .phase0-artifacts/**
+            OPC_UA_Clients/Release2/IJT_Web_Client/test-results/**
+            test-results/**
+          if-no-files-found: ignore
+
+      - name: Job summary
+        if: always()
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
+          WILL_PUBLISH: ${{ steps.decide.outputs.push }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## IJT Browser CI image - Phase 0 build"
+            echo ""
+            echo "- Event: \`${EVENT_NAME}\`"
+            echo "- Ref: \`${REF}\`"
+            echo "- Short SHA: \`${SHORT_SHA}\`"
+            echo "- Will publish: \`${WILL_PUBLISH}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish to GHCR
+    needs: build
+    if: needs.build.outputs.should_push == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute publish tags
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          BUILD_SHORT_SHA: ${{ needs.build.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          TAGS="${IMAGE_NAME}:sha-${BUILD_SHORT_SHA}"
+          if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE_NAME}:main"
+          fi
+          {
+            echo 'tags<<EOF'
+            echo "$TAGS"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Push image (cache from build job)
+        id: push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
+        with:
+          context: .
+          file: .github/docker/ijt-browser-ci/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            IMAGE_BUILD_REF=${{ github.ref }}
+            IMAGE_BUILD_SHA=${{ github.sha }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=ijt-browser-ci
+
+      - name: Verify published image by digest (pull + offline smoke)
+        # Proves GHCR pull permission AND that the digest is usable as
+        # IJT_BROWSER_CI_IMAGE for PR B. Hard gate.
+        run: |
+          set -euo pipefail
+          REF="${IMAGE_NAME}@${{ steps.push.outputs.digest }}"
+          echo "Pulling $REF ..."
+          docker pull "$REF"
+          docker run --rm --network=none "$REF" cat /opt/ijt-browser-ci/metadata.json
+          docker run --rm --network=none "$REF" sh -c 'python --version | grep -E "^Python 3\.14\."'
+          docker run --rm --network=none "$REF" sh -c 'node --version | grep -E "^v24\."'
+
+      - name: Job summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## IJT Browser CI image - Published"
+            echo ""
+            echo "- Tags:"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo "- Digest: \`${{ steps.push.outputs.digest }}\`"
+            echo ""
+            echo "_PR B can pin (paste into \`integration.yml\` or \`image-pin.json\`):_"
+            echo '```'
+            echo "${IMAGE_NAME}@${{ steps.push.outputs.digest }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@
 #   webclient-docker     Web Client             Docker unit/prod tests
 #   int-testclient       Test Client            Windows: OPC UA server (port 40462) + Test Client full suite
 #   live-webclient       Web Client             Windows: local runner web-client-live-* matrix
-#   live-webclient-browser Web Client           Linux stock ubuntu-latest: web-client-e2e-* matrix; Chromium installed by the Web Client runner
+#   live-webclient-browser Web Client           Linux ubuntu-latest: web-client-e2e-* matrix; runs inside owned ghcr.io/.../ijt-browser-ci image (digest pinned in .github/docker/ijt-browser-ci/image-pin.json) with --network=none
 #   live-console         Console Client         Windows: Console Client live tests (port 40461)
 #   csharp-live          C# Client              Windows: xUnit live tests (port 40464) - nightly
 #   report               Combined summary                 Always runs after all jobs
@@ -454,18 +454,23 @@ jobs:
 
   # ───────────────────────────────────────────────────────────────────────────
   # Web Client - Browser E2E Runner Matrix
-  #   Runs every Playwright/headless-Chromium suite on the standard
-  #   ubuntu-latest runner. Chromium and its system dependencies are
-  #   installed at the start of each job by the Web Client runner's
-  #   `_stage_playwright_install()`, which downloads the browser bundle
-  #   matching the locked `@playwright/test` version from
-  #   `cdn.playwright.dev`. The job intentionally does NOT use a job-level
-  #   `container:` image: GitHub creates container-job runtimes before any
-  #   workflow step runs, so a registry pull failure (e.g. transient MCR
-  #   outage) takes the whole job down with no in-job retry, fallback, or
-  #   diagnostics possible. Letting Playwright install its own browsers on
-  #   a stock runner removes that single point of failure entirely; the
-  #   `--with-deps` install path matches Playwright's own CI guidance.
+  #   Runs every Playwright/headless-Chromium suite inside the owned
+  #   `ijt-browser-ci` image published to GHCR by
+  #   `.github/workflows/build-browser-ci-image.yml`. The image is digest-
+  #   pinned via `.github/docker/ijt-browser-ci/image-pin.json` and bakes
+  #   Python 3.14, Node 24, Playwright + Chromium + Linux system libs, the
+  #   pip wheelhouse, and the npm cache. The container runs with
+  #   `--network=none`, `--user $(id -u):$(id -g)`, and
+  #   `-v $GITHUB_WORKSPACE:/workspace`, so the only inputs are the checkout
+  #   tree and the baked caches, and the only outputs are the test-results
+  #   directories under the workspace.
+  #
+  #   The job intentionally does NOT use a job-level `container:` image:
+  #   GitHub creates container-job runtimes before any workflow step runs,
+  #   so a registry pull failure (e.g. transient GHCR outage) takes the
+  #   whole job down with no in-job retry, fallback, or diagnostics
+  #   possible. A step-level `docker run` keeps the pull, the digest guard,
+  #   and the suite invocation inside steps that we control end-to-end.
   #   Windows browser compatibility coverage is tracked separately so the
   #   bulk browser logic suite does not depend on Windows-hosted Chromium
   #   process stability.
@@ -476,6 +481,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -502,18 +508,94 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
-        with:
-          python-version: "3.14"
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
-        with:
-          node-version: "24"
-
-      - name: Run Web Client browser e2e suite
+      - name: Resolve IJT Browser CI image reference (digest-qualified)
+        id: image
         env:
-          IJT_PLAYWRIGHT_SHARD: ${{ matrix.feature_shard || '' }}
-        run: python run_all_tests.py --suite "${{ matrix.suite }}" --verbose
+          PIN_PATH: .github/docker/ijt-browser-ci/image-pin.json
+        run: |
+          set -euo pipefail
+          IMG="$(jq -r .image "$PIN_PATH")"
+          DIG="$(jq -r .digest "$PIN_PATH")"
+          if ! [[ "$DIG" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error file=$PIN_PATH::digest is not a valid sha256:<64hex> reference: $DIG" >&2
+            exit 1
+          fi
+          REF="${IMG}@${DIG}"
+          if ! [[ "$REF" =~ @sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error file=$PIN_PATH::Resolved IJT_BROWSER_CI_IMAGE is not digest-qualified: $REF" >&2
+            exit 1
+          fi
+          echo "ijt_browser_ci_image=$REF" >> "$GITHUB_OUTPUT"
+          echo "Resolved IJT_BROWSER_CI_IMAGE=$REF"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull IJT Browser CI image (3-attempt retry)
+        env:
+          IMG: ${{ steps.image.outputs.ijt_browser_ci_image }}
+          PIN_PATH: .github/docker/ijt-browser-ci/image-pin.json
+        run: |
+          set -euo pipefail
+          # Retry 3x with backoff. GHCR is the SPOF this job depends on; if all
+          # three attempts fail the diagnostic must name the digest, the
+          # registry, and the image-build workflow so the operator can decide
+          # whether to re-run the publish workflow or wait out a GHCR incident.
+          attempt=0
+          max_attempts=3
+          delay=5
+          until docker pull "$IMG"; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "::error file=${PIN_PATH}::Failed to pull IJT Browser CI image after ${max_attempts} attempts." >&2
+              echo "::error::  image:    ${IMG}" >&2
+              echo "::error::  registry: ghcr.io (GHCR)" >&2
+              echo "::error::  pin file: ${PIN_PATH}" >&2
+              echo "::error::  republish: re-run .github/workflows/build-browser-ci-image.yml on main to regenerate this digest, then update ${PIN_PATH}." >&2
+              exit 1
+            fi
+            echo "docker pull attempt ${attempt}/${max_attempts} failed; retrying in ${delay}s..." >&2
+            sleep "$delay"
+            delay=$((delay * 2))
+          done
+          docker image inspect "$IMG" --format 'id={{.Id}} created={{.Created}}'
+
+      - name: Run Web Client browser e2e suite (offline, --network=none)
+        env:
+          IMG: ${{ steps.image.outputs.ijt_browser_ci_image }}
+          SUITE: ${{ matrix.suite }}
+          SHARD: ${{ matrix.feature_shard || '' }}
+        run: |
+          set -euo pipefail
+          # GitHub metadata envs are propagated so the in-container Python
+          # runner can stamp reports/summaries with the run identity. They are
+          # informational only; the run still executes under --network=none.
+          docker run --rm --init \
+            --network=none \
+            --user "$(id -u):$(id -g)" \
+            -w /workspace \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -e CI=1 \
+            -e HOME=/opt/ijt-browser-ci/home \
+            -e npm_config_cache=/opt/ijt-browser-ci/npm-cache \
+            -e npm_config_offline=true \
+            -e PIP_CACHE_DIR=/opt/ijt-browser-ci/pip-cache \
+            -e PIP_NO_INDEX=1 \
+            -e PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse \
+            -e SKIP_VENV_INSTALL=1 \
+            -e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+            -e IJT_PLAYWRIGHT_SHARD="$SHARD" \
+            -e GITHUB_RUN_ID="${GITHUB_RUN_ID}" \
+            -e GITHUB_RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT}" \
+            -e GITHUB_SHA="${GITHUB_SHA}" \
+            -e GITHUB_REPOSITORY="${GITHUB_REPOSITORY}" \
+            -e GITHUB_SERVER_URL="${GITHUB_SERVER_URL}" \
+            "$IMG" \
+            bash -lc "python run_all_tests.py --suite \"$SUITE\" --verbose"
 
       - name: Upload Web Client browser results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -1441,11 +1523,11 @@ jobs:
               "",
               "### Browser E2E Tests",
               "",
-              "> Platform: Ubuntu latest — Chromium installed by `npx playwright install chromium --with-deps` matching the locked `@playwright/test` version in `OPC_UA_Clients/Release2/IJT_Web_Client/package.json`",
+              "> Platform: Ubuntu latest — runs inside the owned `ijt-browser-ci` image (digest-pinned via `.github/docker/ijt-browser-ci/image-pin.json`); Chromium + system libs are baked at image-build time and the container runs with `--network=none`",
               "",
               "| Suite | Surface | Tests | Skipped | Notes |",
               "|:------|:--------|------:|--------:|:------|",
-              f"| Web Client — Browser E2E | Chromium DOM/JS + OPC UA WebSocket + result/event UX | {tests(*wc_browser, baseline=baseline_suite(integration_baseline, 'wc_browser'))} | {skips(wc_browser[3])} | {skip_note_inline(wc_browser_skips, wc_browser[3], 'Headless Chromium installed via Playwright CLI on the runner')} |",
+              f"| Web Client — Browser E2E | Chromium DOM/JS + OPC UA WebSocket + result/event UX | {tests(*wc_browser, baseline=baseline_suite(integration_baseline, 'wc_browser'))} | {skips(wc_browser[3])} | {skip_note_inline(wc_browser_skips, wc_browser[3], 'Headless Chromium baked into the IJT Browser CI image')} |",
           ]
 
           if wc_feature_timings:

--- a/OPC_UA_Clients/Release2/IJT_Web_Client/README.md
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/README.md
@@ -22,7 +22,7 @@ a web browser. The backend is Python with WebSockets. The frontend is Node.js.
 - Local Playwright browser tests need Chromium downloaded from `https://cdn.playwright.dev` over HTTPS.
 - On corporate networks, set `HTTPS_PROXY` for the proxy path or `PLAYWRIGHT_DOWNLOAD_HOST` for an approved mirror before running `npx playwright install chromium`.
 - For offline machines, prepopulate a browser cache and set `PLAYWRIGHT_BROWSERS_PATH` to that mirror/cache location.
-- For CI-equivalent browser dependencies, the Integration `live-webclient-browser` job runs on stock `ubuntu-latest` and installs Chromium with `npx playwright install chromium --with-deps` against the locked `@playwright/test` version in [`package.json`](./package.json); reproduce that same path locally on a Linux host (or WSL) to match CI exactly. See [`docs/TEST_TIERS.md`](../../../docs/TEST_TIERS.md) for the full tier description.
+- For CI-equivalent browser dependencies, the Integration `live-webclient-browser` job runs each suite **inside** the owned `ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci` image (digest pinned via [`.github/docker/ijt-browser-ci/image-pin.json`](../../../.github/docker/ijt-browser-ci/image-pin.json)) started with `docker run --network=none`; Chromium and its Linux system dependencies are baked into the image at build time against the locked `@playwright/test` version in [`package.json`](./package.json). Local Linux developers can reproduce the same browser/system-deps surface via `npx playwright install chromium --with-deps`, but local Web E2E itself does **not** require Docker or GHCR access. See [`docs/TEST_TIERS.md`](../../../docs/TEST_TIERS.md) for the full tier description.
 
 ## Option 1 - Local Setup
 

--- a/OPC_UA_Clients/Release2/IJT_Web_Client/docs/SKILLS.md
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/docs/SKILLS.md
@@ -436,11 +436,14 @@ Vitest, ESLint, mypy, Bandit, and audit commands, and the split gives each
 language stack its own timing and failure surface. GitHub `integration.yml`
 runs the same root-runner Web Client live/e2e suites as local validation, split
 by execution surface. `web-client-live-*` suites stay on `windows-latest` with
-the Windows simulator package. Every `web-client-e2e-*` suite runs on stock
-`ubuntu-latest`; Chromium and its system dependencies are installed at the
-start of each suite by the Web Client runner via
-`npx playwright install chromium --with-deps` against the locked
-`@playwright/test` version. No job-level `container:` image is used —
+the Windows simulator package. Every `web-client-e2e-*` suite runs inside the
+owned `ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci`
+image, digest-pinned via `.github/docker/ijt-browser-ci/image-pin.json` and
+started with `docker run --network=none`; Chromium, its Linux system
+dependencies, the locked `@playwright/test` version, Python 3.14, and Node 24
+are all baked into the image. The host runner never executes
+`npx playwright install chromium --with-deps`. No job-level `container:`
+image is used —
 container-job images are pulled by GitHub before any step runs, so a
 registry outage would take the whole job down with no in-job retry,
 fallback, or diagnostics. Browser Features keeps two Playwright shards

--- a/OPC_UA_Clients/Release2/IJT_Web_Client/run_all_tests.py
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/run_all_tests.py
@@ -1391,16 +1391,17 @@ def _stage_playwright_install() -> StageResult:
             label="playwright install chromium --with-deps",
             env=env,
         )
-        # ``--with-deps`` is the load-bearing CI contract on Linux: the
-        # Integration ``live-webclient-browser`` job runs on stock
-        # ``ubuntu-latest`` and relies on this stage to install Chromium
-        # plus its Linux system libraries. Falling back to a bare
-        # ``playwright install chromium`` after ``--with-deps`` fails
-        # would let the install stage report success while the browser
-        # would crash at first launch because libnss3/libatk/etc. are
-        # missing. In CI we therefore fail fast on ``--with-deps``
-        # failure so the job surfaces the real cause instead of a later
-        # opaque browser-launch error in the Playwright suite.
+        # In GitHub Integration, ``live-webclient-browser`` runs inside the
+        # owned browser CI image. Chromium and its Linux libraries are baked
+        # into that image, so this stage should normally short-circuit before
+        # reaching the install command. If a CI-shaped run ever reaches this
+        # fallback path, ``--with-deps`` is still required: falling back to a
+        # bare ``playwright install chromium`` after ``--with-deps`` fails
+        # would let the install stage report success while the browser would
+        # crash at first launch because libnss3/libatk/etc. are missing.
+        # In CI we therefore fail fast on ``--with-deps`` failure so the job
+        # surfaces the real cause instead of a later opaque browser-launch
+        # error in the Playwright suite.
         #
         # On a local developer Linux machine the system libraries are
         # almost always already installed by the distro, so the bare

--- a/OPC_UA_Clients/Release2/IJT_Web_Client/tests/python/unit/test_runner_environment.py
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/tests/python/unit/test_runner_environment.py
@@ -949,19 +949,25 @@ def test_playwright_install_skips_with_deps_on_windows(monkeypatch):
 
 
 def test_playwright_install_uses_with_deps_on_linux(monkeypatch):
-    """Linux ``_stage_playwright_install`` must invoke ``--with-deps``.
+    """Linux ``_stage_playwright_install`` must invoke ``--with-deps`` when
+    Chromium is not already present.
 
-    This is the permanent replacement path for the previously pinned
-    ``mcr.microsoft.com/playwright`` job-level container in
-    ``.github/workflows/integration.yml`` (``live-webclient-browser``).
-    The Integration job now runs on stock ``ubuntu-latest`` and relies
-    on this stage to install Chromium plus its Linux system
-    dependencies against the locked ``@playwright/test`` version in
-    ``package.json``. If the ``--with-deps`` invocation ever regresses
-    to a bare ``playwright install chromium`` on Linux, the CI job will
-    succeed in installing the browser binary but fail at first launch
-    on a fresh runner because the required system libraries are not
-    present. This test guards that contract.
+    Post-PR-B context: the Integration ``live-webclient-browser`` job runs
+    each suite **inside** the owned ``ijt-browser-ci`` image (digest pinned
+    via ``.github/docker/ijt-browser-ci/image-pin.json``) under
+    ``docker run --network=none``. The image bakes Chromium at
+    ``PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`` against the locked
+    ``@playwright/test`` version in ``package.json``, so in the real CI run
+    ``_playwright_chromium_available()`` is True and this stage short-circuits
+    (see ``test_playwright_install_short_circuits_when_chromium_present``).
+
+    However, the ``--with-deps`` Linux path is still the contract for any
+    Linux execution where Chromium is **not** already present — for example,
+    a developer running the suite locally on a fresh Linux/WSL host, or a
+    future contingency where someone runs this stage outside the
+    ``ijt-browser-ci`` image. Dropping ``--with-deps`` from that path would
+    silently install the browser binary without its Linux system libraries
+    and fail at first launch. This test guards that fallback contract.
     """
     runner = _load_runner()
     calls = []
@@ -984,25 +990,27 @@ def test_playwright_install_uses_with_deps_on_linux(monkeypatch):
     assert result.rc == 0
     assert calls == [["/usr/local/bin/playwright", "install", "chromium", "--with-deps"]], (
         "Linux `_stage_playwright_install` must invoke "
-        "`playwright install chromium --with-deps`. This is the permanent "
-        "replacement for the removed Playwright job-level container in "
-        "integration.yml's `live-webclient-browser` job; dropping "
-        "`--with-deps` would leave Chromium without its Linux system "
-        "libraries on stock ubuntu-latest runners and fail at first launch."
+        "`playwright install chromium --with-deps` whenever Chromium is not "
+        "already present. In the Integration `live-webclient-browser` job "
+        "this stage normally short-circuits because Chromium is baked into "
+        "the `ijt-browser-ci` image, but if this Linux path is ever reached "
+        "(local Linux dev, image regression, etc.) dropping `--with-deps` "
+        "would leave Chromium without its Linux system libraries and fail "
+        "at first launch."
     )
 
 
 def test_playwright_install_fails_fast_in_ci_when_with_deps_fails(monkeypatch):
-    """CI Linux must not silently fall back to bare `playwright install chromium`.
+    """CI Linux must not silently fall back to bare ``playwright install chromium``.
 
-    On stock ``ubuntu-latest`` the ``--with-deps`` invocation is the
-    only step that installs the system libraries Chromium needs at
-    runtime (libnss3, libatk, libcups, etc.). A bare fallback would let
-    the install stage report success while the actual browser launch
-    would fail later inside the Playwright suite with an opaque error.
-    Integration's ``live-webclient-browser`` job therefore relies on
-    this stage failing fast in CI so the real cause surfaces at the
-    install step, not deep in a downstream test run.
+    Post-PR-B the Integration ``live-webclient-browser`` job runs inside the
+    owned ``ijt-browser-ci`` image where Chromium is pre-installed, so this
+    stage normally short-circuits. But if a future image rebuild fails to bake
+    Chromium, or a contributor runs the runner in a CI-shaped environment
+    without the image, the only remaining path that installs system libraries
+    is ``--with-deps``. A bare fallback would let install report success while
+    the actual browser launch would fail later inside the Playwright suite
+    with an opaque error. This test guards that CI fail-fast contract.
     """
     runner = _load_runner()
     calls = []
@@ -1667,11 +1675,13 @@ def test_playwright_config_uses_runtime_ui_port_and_no_retries():
     assert "outputFile: `${TEST_RESULTS_DIR}/playwright.xml`" in source
     assert "const PLAYWRIGHT_WORKERS" in source
     assert "process.env.IJT_PLAYWRIGHT_WORKERS" in source
-    # Browser e2e CI installs Chromium via the Web Client runner's
-    # ``npx playwright install chromium --with-deps`` step, not a pinned
-    # container image. This guard prevents anyone from re-introducing
-    # the old image-pin shape that coupled the config to a specific MCR
-    # digest and silently re-coupled CI to a registry SPOF.
+    # Browser e2e CI runs inside the owned `ijt-browser-ci` image (digest
+    # pinned in `.github/docker/ijt-browser-ci/image-pin.json`); Chromium is
+    # baked into the image and the locked `@playwright/test` version in
+    # `package.json` is the single source of truth for the browser bundle.
+    # This guard prevents anyone from re-introducing the old image-pin shape
+    # that coupled the playwright.config to a specific MCR digest and silently
+    # re-coupled CI to a registry SPOF.
     assert "canonicalPlaywrightImage" not in source, (
         "playwright.config.mjs must not export a canonicalPlaywrightImage "
         "metadata field. Browser e2e CI no longer runs inside a job-level "
@@ -1680,10 +1690,9 @@ def test_playwright_config_uses_runtime_ui_port_and_no_retries():
     )
     assert "mcr.microsoft.com/playwright" not in source, (
         "playwright.config.mjs must not reference an MCR Playwright image "
-        "digest. Browser e2e CI installs Chromium via "
-        "`npx playwright install chromium --with-deps` against the locked "
-        "@playwright/test version; any image reference in the config is "
-        "stale and misleads contributors."
+        "digest. Browser e2e CI runs inside the owned `ijt-browser-ci` "
+        "image (digest pinned in `.github/docker/ijt-browser-ci/image-pin.json`); "
+        "any MCR reference in the config is stale and misleads contributors."
     )
     assert "baseURL: UI_BASE_URL" in source
     assert "reuseExistingServer: false" in source

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -403,14 +403,14 @@ Advanced Setup (GitHub Default Setup disabled). Uses `security-extended` queries
 | `web-client-live-opcua-direct` | local root runner + `integration.yml` | OPC UA 40463 | Direct Python OPC UA and method tests |
 | `web-client-live-websocket-api` | local root runner + `integration.yml` | OPC UA 40466 / WS 8002 | Python WebSocket backend contract and integration tests |
 | `web-client-live-websocket-connection` | local root runner + `integration.yml` | OPC UA 40467 / WS 8003 | WebSocket lifecycle tests isolated from backend contract tests |
-| `web-client-e2e-smoke` | local root runner + `integration.yml` | HTTP 3004 | Playwright smoke project; GitHub Integration runs it on stock `ubuntu-latest` with Chromium installed by the Web Client runner |
-| `web-client-e2e-features` | local root runner + `integration.yml` | OPC UA 40469–40472 / WS 8005–8008 / HTTP 3005 | Playwright feature specs with owned browser/backend/server workers; GitHub Integration uses two Browser Features shards on stock `ubuntu-latest` with Chromium installed by the Web Client runner |
-| `web-client-e2e-regression` | local root runner + `integration.yml` | OPC UA 40480 / WS 8010 / HTTP 3006 | Playwright regression spec; GitHub Integration runs it on stock `ubuntu-latest` with Chromium installed by the Web Client runner |
+| `web-client-e2e-smoke` | local root runner + `integration.yml` | HTTP 3004 | Playwright smoke project; GitHub Integration runs it inside the owned `ghcr.io/.../ijt-browser-ci` image (digest pinned in `.github/docker/ijt-browser-ci/image-pin.json`) under `docker run --network=none` |
+| `web-client-e2e-features` | local root runner + `integration.yml` | OPC UA 40469–40472 / WS 8005–8008 / HTTP 3005 | Playwright feature specs with owned browser/backend/server workers; GitHub Integration uses two Browser Features shards inside the owned `ijt-browser-ci` image under `docker run --network=none` |
+| `web-client-e2e-regression` | local root runner + `integration.yml` | OPC UA 40480 / WS 8010 / HTTP 3006 | Playwright regression spec; GitHub Integration runs it inside the owned `ijt-browser-ci` image under `docker run --network=none` |
 | Web Client Compatibility Smoke | Web runner + `web-client-compatibility-smoke.yml` | OPC UA 40468 / WS 8004 / HTTP 3007 | Scheduled/manual smoke for audited browser file surfaces; current matrix runs `windows-latest` / `msedge` |
 | `web-client-docker-smoke` | local root runner | HTTP 3000 / WS 8001 | Web Client production Docker image/readiness smoke |
 | `int-testclient` | `integration.yml` | **40462** | Windows native EXE |
 | `live-webclient` | `integration.yml` | **40463/40466/40467** | Windows native EXE for non-browser Web Client live suites |
-| `live-webclient-browser` | `integration.yml` | **40469–40472 / 40480** | Stock `ubuntu-latest`; Chromium installed by the Web Client runner via `npx playwright install chromium --with-deps` against the locked `@playwright/test` version; Linux simulator package |
+| `live-webclient-browser` | `integration.yml` | **40469–40472 / 40480** | `ubuntu-latest` host runner; suites execute **inside** the owned `ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci` image (digest pinned via `.github/docker/ijt-browser-ci/image-pin.json`) under `docker run --network=none`; Chromium, Linux system libraries, Python 3.14, and Node 24 are baked into the image; the Linux simulator binary comes from the mounted checkout |
 | `live-console` | `integration.yml` | **40461** | Windows native EXE |
 | `csharp-live` (nightly) | `integration.yml` | **40464** | Windows native EXE |
 
@@ -428,11 +428,14 @@ GitHub integration runs the same Web Client live/e2e suites through the root
 runner matrix, split by execution surface. The non-browser Web Client live
 suites stay on `windows-latest` because they validate Python/backend behavior
 against the Windows simulator package. All `web-client-e2e-*` Playwright suites
-runs `python run_all_tests.py --suite` so Chromium and its system
-dependencies are installed at the start of each suite by the Web Client
-runner via `npx playwright install chromium --with-deps` against the
-locked `@playwright/test` version in
-`OPC_UA_Clients/Release2/IJT_Web_Client/package.json`. The job
+runs `python run_all_tests.py --suite` **inside** the owned
+`ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci`
+image, digest-pinned via `.github/docker/ijt-browser-ci/image-pin.json`
+and started with `docker run --network=none`. Chromium, its Linux
+system dependencies, the locked `@playwright/test` version, the
+Python 3.14 toolchain, and the Node 24 toolchain are all baked into
+the image — the host runner never reaches `npx playwright install
+chromium --with-deps`. The job
 deliberately does NOT declare a job-level `container:` image because
 GitHub creates container-job runtimes before any workflow step runs, so
 a registry pull failure (transient MCR outage, network reroute, etc.)

--- a/docs/TEST_TIERS.md
+++ b/docs/TEST_TIERS.md
@@ -167,10 +167,14 @@ run their live/integration tests in parallel without port conflicts.
 > GitHub integration runs that same local root-runner suite matrix instead of
 > a separate raw pytest-only Web integration command. The non-browser Web live
 > suites stay on GitHub-hosted Windows runners. Every `web-client-e2e-*`
-> Playwright suite runs on stock `ubuntu-latest`; Chromium and its system
-> dependencies are installed at the start of each suite by the Web Client
-> runner via `npx playwright install chromium --with-deps` against the locked
-> `@playwright/test` version. No job-level `container:` image is used:
+> Playwright suite runs inside the owned
+> `ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci` image,
+> digest-pinned via `.github/docker/ijt-browser-ci/image-pin.json` and started
+> with `docker run --network=none`. Chromium, its Linux system dependencies,
+> the locked `@playwright/test` version, Python 3.14, and Node 24 are all baked
+> into the image — the host runner never reaches
+> `npx playwright install chromium --with-deps`. No job-level `container:`
+> image is used:
 > container-job images are pulled by GitHub before any step runs, so a
 > registry outage would take the whole job down with no in-job retry,
 > fallback, or diagnostics. Browser Features keeps two shards; CI

--- a/tests/test_image_pin.py
+++ b/tests/test_image_pin.py
@@ -1,0 +1,195 @@
+"""Contract test for .github/docker/ijt-browser-ci/image-pin.json.
+
+The integration.yml live-webclient-browser job constructs IJT_BROWSER_CI_IMAGE
+as `${image}@${digest}` at runtime and refuses any tag-only reference. This
+test catches malformed pin files at PR time (faster feedback than a CI workflow
+syntax/regex failure on Linux runners).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PIN_PATH = _REPO_ROOT / ".github" / "docker" / "ijt-browser-ci" / "image-pin.json"
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_DIGEST_REF_SUFFIX_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+_IMAGE_RE = re.compile(r"^ghcr\.io/[a-z0-9._/-]+$")
+
+
+@pytest.fixture(scope="module")
+def pin() -> dict:
+    assert _PIN_PATH.is_file(), f"missing image-pin.json: {_PIN_PATH}"
+    with _PIN_PATH.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_image_pin_required_keys(pin: dict) -> None:
+    for key in ("image", "digest", "playwright_version", "node_version", "python_version"):
+        assert key in pin, f"image-pin.json missing required key: {key}"
+
+
+def test_image_pin_digest_is_sha256_64hex(pin: dict) -> None:
+    assert _SHA256_RE.match(pin["digest"]), (
+        f"image-pin.json digest must match ^sha256:[0-9a-f]{{64}}$, got: {pin['digest']!r}"
+    )
+
+
+def test_image_pin_image_is_ghcr_lowercase(pin: dict) -> None:
+    assert _IMAGE_RE.match(pin["image"]), (
+        f"image-pin.json image must be a lowercase ghcr.io reference, got: {pin['image']!r}"
+    )
+
+
+def test_image_pin_reference_is_digest_qualified(pin: dict) -> None:
+    ref = f"{pin['image']}@{pin['digest']}"
+    assert _DIGEST_REF_SUFFIX_RE.search(ref), (
+        f"constructed IJT_BROWSER_CI_IMAGE is not digest-qualified: {ref!r}"
+    )
+
+
+def test_image_pin_no_floating_tag(pin: dict) -> None:
+    assert ":" not in pin["image"].split("/")[-1], (
+        "image-pin.json 'image' must not contain a tag (':') in the final segment, "
+        f"got: {pin['image']!r}"
+    )
+
+
+def test_image_pin_playwright_version_matches_package_lock(pin: dict) -> None:
+    """The pinned CI image must track the Web Client's locked Playwright version."""
+    lock_path = _IJT_WEB_CLIENT_DIR / "package-lock.json"
+    assert lock_path.is_file(), f"missing Web Client package-lock.json: {lock_path}"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    package = lock.get("packages", {}).get("node_modules/@playwright/test")
+    assert package, "package-lock.json is missing node_modules/@playwright/test"
+    assert pin["playwright_version"] == package["version"], (
+        "image-pin.json playwright_version must match package-lock.json "
+        "node_modules/@playwright/test. Rebuild/publish ijt-browser-ci and "
+        "update image-pin.json in the same Playwright bump."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Local/CI separation contracts
+# ---------------------------------------------------------------------------
+#
+# The owned ijt-browser-ci image is a CI-only concern: only the GitHub Actions
+# workflow that runs `live-webclient-browser` in `integration.yml` should
+# reference IJT_BROWSER_CI_IMAGE / the ijt-browser-ci GHCR image. Local
+# developer execution of Web E2E (root runner + Web Client runner) must NOT
+# require GHCR access for the browser image; it must keep using the locked
+# `@playwright/test` version directly. (The root runner does legitimately use
+# `docker run` for the Linux server-simulator package smoke against a
+# different image — that path is unrelated and remains allowed.)
+# These contract tests guard that separation at PR time.
+
+_IJT_WEB_CLIENT_DIR = _REPO_ROOT / "OPC_UA_Clients" / "Release2" / "IJT_Web_Client"
+_ROOT_RUNNER = _REPO_ROOT / "run_all_tests.py"
+_WEB_CLIENT_RUNNER = _IJT_WEB_CLIENT_DIR / "run_all_tests.py"
+
+_FORBIDDEN_CI_TOKENS_IN_PRODUCTION_RUNNERS = (
+    "IJT_BROWSER_CI_IMAGE",
+    "ijt-browser-ci",
+    "ghcr.io/umati",
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"expected production runner script at {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _tracked_files() -> list[Path]:
+    git = shutil.which("git")
+    assert git, "git executable is required for repo-wide image-pin boundary checks"
+    result = subprocess.run(
+        [git, "ls-files"],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [_REPO_ROOT / line for line in result.stdout.splitlines() if line]
+
+
+@pytest.mark.parametrize(
+    "runner_path",
+    [_ROOT_RUNNER, _WEB_CLIENT_RUNNER],
+    ids=["root_runner", "web_client_runner"],
+)
+def test_python_runners_do_not_reference_ci_image(runner_path: Path) -> None:
+    """Production Python runners must not embed IJT_BROWSER_CI_IMAGE / GHCR image.
+
+    The CI image is wired in `.github/workflows/integration.yml` only. If a
+    Python runner ever started reading IJT_BROWSER_CI_IMAGE or calling
+    `docker pull` / `docker run`, local developer execution would gain a
+    hidden CI dependency. This test catches that regression at PR time.
+    """
+    source = _read(runner_path)
+    for token in _FORBIDDEN_CI_TOKENS_IN_PRODUCTION_RUNNERS:
+        assert token not in source, (
+            f"{runner_path.name} must not reference {token!r}: the ijt-browser-ci "
+            "image is a CI-only concern wired in `.github/workflows/integration.yml`. "
+            "Embedding it in a Python runner forces local developers onto Docker/GHCR."
+        )
+
+
+def test_ijt_browser_ci_image_env_var_is_workflow_or_image_config_only() -> None:
+    """The CI image env var must stay out of product/runtime code."""
+    token = "IJT_" + "BROWSER_CI_" + "IMAGE"
+    allowed_prefixes = (
+        Path(".github/workflows"),
+        Path(".github/docker/ijt-browser-ci"),
+    )
+    allowed_exact = {Path("tests/test_image_pin.py")}
+    offenders: list[str] = []
+
+    for path in _tracked_files():
+        rel = path.relative_to(_REPO_ROOT)
+        if rel in allowed_exact or any(rel.is_relative_to(prefix) for prefix in allowed_prefixes):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if token in text:
+            offenders.append(rel.as_posix())
+
+    assert not offenders, (
+        "IJT_BROWSER_CI_IMAGE is workflow/image-config only. It must not leak "
+        "into Python runners, product code, or general docs: " + ", ".join(sorted(offenders))
+    )
+
+
+def test_local_web_e2e_does_not_require_docker_or_ghcr() -> None:
+    """Web Client runner module + package.json must not require Docker or GHCR for local E2E.
+
+    Browser e2e is a local-friendly target: ``cd OPC_UA_Clients/Release2/IJT_Web_Client``
+    then ``python run_all_tests.py --suite web-client-e2e-smoke`` must work
+    against the locked ``@playwright/test`` Chromium without Docker, without
+    GHCR credentials, and without any reference to the ijt-browser-ci image.
+    """
+    web_client_runner = _read(_WEB_CLIENT_RUNNER)
+    for token in _FORBIDDEN_CI_TOKENS_IN_PRODUCTION_RUNNERS:
+        assert token not in web_client_runner, (
+            f"Web Client runner references {token!r}; local E2E must not require "
+            "Docker or GHCR. Move any CI-specific logic into "
+            "`.github/workflows/integration.yml` instead."
+        )
+
+    package_json_path = _IJT_WEB_CLIENT_DIR / "package.json"
+    assert package_json_path.is_file(), f"missing {package_json_path}"
+    package_json_text = package_json_path.read_text(encoding="utf-8")
+    for token in ("ijt-browser-ci", "ghcr.io/umati"):
+        assert token not in package_json_text, (
+            f"Web Client package.json references {token!r}; the locked "
+            "`@playwright/test` version is the single source of truth for the "
+            "local browser bundle. CI image references belong in the workflow."
+        )

--- a/tests/test_root_runner.py
+++ b/tests/test_root_runner.py
@@ -1049,7 +1049,14 @@ def test_integration_web_client_e2e_jobs_run_on_stock_ubuntu_runner() -> None:
         assert "build-browser-ci-image.yml" in pull_body, (
             "Pull step diagnostic must name the image-build workflow so operators can republish."
         )
-        assert "ghcr.io" in pull_body, "Pull step diagnostic must name the registry (ghcr.io)."
+        # Match the precise diagnostic phrase from integration.yml so this
+        # assertion can't be misread as URL-substring sanitization (CodeQL
+        # py/incomplete-url-substring-sanitization false-positive on the
+        # bare "ghcr.io" substring).
+        assert "ghcr.io (GHCR)" in pull_body, (
+            "Pull step diagnostic must name the registry as `ghcr.io (GHCR)` "
+            "so the operator immediately knows which registry failed."
+        )
 
         run_step = next(
             step

--- a/tests/test_root_runner.py
+++ b/tests/test_root_runner.py
@@ -960,20 +960,19 @@ def test_integration_web_client_features_are_sharded() -> None:
 
 
 def test_integration_web_client_e2e_jobs_run_on_stock_ubuntu_runner() -> None:
-    """Browser e2e must stay off Windows-hosted Chromium and off job-level container images.
+    """Browser e2e must run inside the owned ijt-browser-ci image with --network=none.
 
     History: a job-level ``container: image: mcr.microsoft.com/playwright:...``
-    block previously ran every browser suite, but a job-level container image
-    is pulled by GitHub *before* any workflow step runs. A transient MCR
-    outage took the whole job down with no in-job retry, fallback, or
-    diagnostics possible. The job now uses ``runs-on: ubuntu-latest`` with
-    no container image; Chromium and its system deps are installed at the
-    start of each suite by the Web Client runner's
-    ``_stage_playwright_install()`` (which runs ``npx playwright install
-    chromium --with-deps`` against the locked ``@playwright/test`` version),
-    matching Playwright's own CI guidance. This regression gate prevents
-    re-introducing a job-level ``container:`` block or moving e2e onto
-    Windows-hosted Chromium.
+    block once ran every browser suite, but a job-level container image is
+    pulled by GitHub *before* any workflow step runs, so a transient registry
+    outage took the whole job down with no in-job retry. PR A introduced the
+    owned ``ghcr.io/.../ijt-browser-ci`` image (digest-pinned via
+    ``.github/docker/ijt-browser-ci/image-pin.json``) and PR B wires it into
+    this job via a step-level ``docker run --network=none``, so pull + run +
+    diagnostics all happen inside steps the job controls end-to-end. This
+    regression gate prevents re-introducing a job-level ``container:`` block,
+    re-introducing live ``npx playwright install --with-deps`` on the host
+    runner, or moving e2e onto Windows-hosted Chromium.
     """
     import yaml
 
@@ -996,36 +995,97 @@ def test_integration_web_client_e2e_jobs_run_on_stock_ubuntu_runner() -> None:
             "live-webclient-browser must not use a job-level container image: "
             "GitHub pulls container-job images before any step runs, so a "
             "registry outage takes the whole job down with no in-job retry. "
-            "Chromium is installed by the Web Client runner via "
-            "`npx playwright install chromium --with-deps`."
+            "The job uses a step-level `docker run` against the owned "
+            "ijt-browser-ci image instead."
         )
-        assert "PLAYWRIGHT_BROWSERS_PATH" not in job.get("env", {}), (
-            "PLAYWRIGHT_BROWSERS_PATH was the bundled-image install location "
-            "(/ms-playwright). With Playwright installing Chromium itself, "
-            "the default path is correct."
+        assert job.get("permissions", {}).get("packages") == "read", (
+            "live-webclient-browser must declare `permissions: packages: read` "
+            "to authenticate against GHCR for the ijt-browser-ci pull."
         )
 
         steps = job["steps"]
         step_names = [step.get("name") or step.get("uses", "") for step in steps]
-        assert not any("Install setup-python OS helper" in name for name in step_names), (
-            "The lsb-release helper step was needed only inside the slim "
-            "Playwright container image. ubuntu-latest already has lsb-release."
+
+        assert not any(
+            step.get("uses", "").startswith("actions/setup-python@") for step in steps
+        ), (
+            "setup-python is baked into the ijt-browser-ci image; the host "
+            "runner must not install its own Python."
         )
-        setup_python_step = next(
-            step for step in steps if step.get("uses", "").startswith("actions/setup-python@")
+        assert not any(step.get("uses", "").startswith("actions/setup-node@") for step in steps), (
+            "setup-node is baked into the ijt-browser-ci image; the host "
+            "runner must not install its own Node."
         )
-        setup_node_step = next(
-            step for step in steps if step.get("uses", "").startswith("actions/setup-node@")
+
+        resolve_step = next(
+            step
+            for step in steps
+            if step.get("name") == "Resolve IJT Browser CI image reference (digest-qualified)"
         )
-        assert setup_python_step.get("with", {}).get("python-version") == "3.14"
-        assert setup_node_step.get("with", {}).get("node-version") == "24"
-        assert "cache" not in setup_python_step.get("with", {})
-        assert "cache" not in setup_node_step.get("with", {})
+        assert (
+            resolve_step.get("env", {}).get("PIN_PATH")
+            == ".github/docker/ijt-browser-ci/image-pin.json"
+        )
+        assert "^sha256:[0-9a-f]{64}$" in resolve_step["run"], (
+            "Resolve step must guard that the digest is sha256:<64hex>."
+        )
+
+        login_step = next(
+            step for step in steps if step.get("uses", "").startswith("docker/login-action@")
+        )
+        assert login_step.get("with", {}).get("registry") == "ghcr.io"
+
+        pull_step = next(
+            step
+            for step in steps
+            if step.get("name") == "Pull IJT Browser CI image (3-attempt retry)"
+        )
+        pull_body = pull_step["run"]
+        assert "docker pull" in pull_body
+        assert "max_attempts=3" in pull_body, (
+            "Pull step must retry 3x; transient GHCR errors must not fail "
+            "the job on a single attempt."
+        )
+        assert "build-browser-ci-image.yml" in pull_body, (
+            "Pull step diagnostic must name the image-build workflow so operators can republish."
+        )
+        assert "ghcr.io" in pull_body, "Pull step diagnostic must name the registry (ghcr.io)."
 
         run_step = next(
-            step for step in steps if step.get("name") == "Run Web Client browser e2e suite"
+            step
+            for step in steps
+            if step.get("name") == "Run Web Client browser e2e suite (offline, --network=none)"
         )
-        assert "python run_all_tests.py --suite" in run_step["run"]
+        run_body = run_step["run"]
+        assert "docker run" in run_body
+        assert "--network=none" in run_body
+        assert '--user "$(id -u):$(id -g)"' in run_body
+        assert '-v "${GITHUB_WORKSPACE}:/workspace"' in run_body
+        assert "PIP_NO_INDEX=1" in run_body
+        assert "npm_config_offline=true" in run_body
+        assert "SKIP_VENV_INSTALL=1" in run_body
+        assert "PLAYWRIGHT_BROWSERS_PATH=/ms-playwright" in run_body
+        assert "python run_all_tests.py --suite" in run_body
+        for required_env in (
+            "GITHUB_RUN_ID",
+            "GITHUB_RUN_ATTEMPT",
+            "GITHUB_SHA",
+            "GITHUB_REPOSITORY",
+            "GITHUB_SERVER_URL",
+        ):
+            assert required_env in run_body, (
+                f"Run step must propagate {required_env} into the container so "
+                "in-container reports/summaries can stamp the run identity."
+            )
+
+        assert not any("Install setup-python OS helper" in name for name in step_names), (
+            "The lsb-release helper step was only needed for the slim Playwright "
+            "container image and must not be reintroduced."
+        )
+        assert not any("npx playwright install" in (step.get("run") or "") for step in steps), (
+            "Live `npx playwright install --with-deps` on the host runner is "
+            "forbidden; Chromium + deps are baked into the ijt-browser-ci image."
+        )
 
 
 def test_compatibility_smoke_workflow_is_schedule_only_matrix_detection() -> None:


### PR DESCRIPTION
## Summary

PR B of the IJT Browser CI image slice. Wires the owned, digest-pinned `ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci` image (published by PR A, commit 3768a248) into `integration.yml`'s `live-webclient-browser` matrix via step-level `docker run --network=none`. Local Web E2E continues to work without Docker or GHCR — the image is a CI-only concern.

## What changes

1. **`.github/docker/ijt-browser-ci/image-pin.json` (new)** — single source of truth for the digest (`sha256:b94c883d…`), Playwright version, Node/Python versions, image revision, and provenance metadata.
2. **`.github/workflows/integration.yml`** — `live-webclient-browser` job rewritten:
   - Drops `actions/setup-python` and `actions/setup-node` (baked into the image).
   - Adds `permissions: packages: read`.
   - New steps: **Resolve** (jq + sha256 regex guard from `image-pin.json`) → **GHCR login** (digest-pinned `docker/login-action@v4`) → **Pull** (3-attempt retry with backoff and operator-actionable diagnostic) → **Run** (`docker run --rm --init --network=none --user $(id -u):$(id -g) -v $GITHUB_WORKSPACE:/workspace` with `PIP_NO_INDEX=1`, `npm_config_offline=true`, `SKIP_VENV_INSTALL=1`, `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, and propagated `GITHUB_RUN_ID/RUN_ATTEMPT/SHA/REPOSITORY/SERVER_URL`).
   - All `${{ … }}` references bound to step `env:` for zizmor cleanliness.
3. **Contract tests** (new and updated):
   - `tests/test_image_pin.py` — pin schema, sha256 digest regex, ghcr.io lowercase, digest-qualified reference, no floating tag, **Playwright drift guard** matching `package-lock.json node_modules/@playwright/test`, Python-runner CI-image boundary, repo-wide `IJT_BROWSER_CI_IMAGE` workflow/image-config-only boundary, and local Web E2E independence from Docker/GHCR.
   - `tests/test_root_runner.py` — `test_integration_web_client_e2e_jobs_run_on_stock_ubuntu_runner` updated to assert the new contract: no `setup-python`/`setup-node`, `packages: read`, Resolve+sha256 guard, GHCR login, 3-attempt pull with `build-browser-ci-image.yml` named in the diagnostic, and all 5 `GITHUB_*` envs in the run step.
   - `OPC_UA_Clients/Release2/IJT_Web_Client/tests/python/unit/test_runner_environment.py` — docstrings + assertion messages updated: `--with-deps` is now the fallback/local-Linux contract; the CI path short-circuits because Chromium is baked into the image.
4. **Docs** — `docs/SKILLS.md`, `docs/TEST_TIERS.md`, `OPC_UA_Clients/Release2/IJT_Web_Client/docs/SKILLS.md`, `OPC_UA_Clients/Release2/IJT_Web_Client/README.md` updated to describe the new CI path. README explicitly states local E2E does **not** require Docker or GHCR. `docs/SKILLS.md` clarifies the Linux simulator binary still comes from the mounted checkout.
5. **`OPC_UA_Clients/Release2/IJT_Web_Client/run_all_tests.py`** — comment block in `_stage_playwright_install()` updated: `--with-deps` is no longer described as "the load-bearing CI contract on stock ubuntu-latest"; it's the fallback path that the CI image normally short-circuits past.

## Why step-level `docker run` (not job-level `container:`)

A job-level `container:` image is pulled by GitHub **before any workflow step runs**, so a transient GHCR outage takes the whole job down with no in-job retry, fallback, or diagnostic possible. The step-level `docker run` keeps the pull, the 3-attempt retry, the digest guard, and the suite invocation inside steps the workflow controls end-to-end.

## Verification

- Pre-commit: every hook **Passed** (ruff, ruff-format, mixed-line-ending, check-yaml, check-json, workflow-policy-guard, validate-github-workflows, **zizmor**, **actionlint**, optional-import-typing-guard).
- pytest: **159/159 passed** across `tests/test_image_pin.py`, `tests/test_root_runner.py`, and `test_runner_environment.py`.
- Playwright drift guard verified empirically: `image-pin.json.playwright_version == package-lock.json node_modules/@playwright/test.version == 1.60.0`.

## Decisive gate

The 4 `live-webclient-browser` matrix rows (smoke, features 1/2, features 2/2, regression) must pass under `--network=none` against the digest-pinned image. Anything else passing/skipping is informational; the offline-container run is the contract.

## Follow-ups (NOT in this PR)

- Renovate/drift-guard automation to bump `image-pin.json` when the image-build workflow republishes (currently manual).
- Cleanup of local `spike-browser-ci/` directory (PR A spike, now obsolete since the digest is captured here).
