### PR TITLE
Automate IJT Browser CI image pin via reviewed PR

### DIFF
--- a/.github/docker/ijt-browser-ci/README.md
+++ b/.github/docker/ijt-browser-ci/README.md
@@ -10,11 +10,24 @@ commit `4ad418b5`.
 
 - `Dockerfile` — image definition (Python 3.14, Node 24, Playwright 1.60.0
   + Chromium + Linux system libs; wheelhouse + npm cache pre-warmed).
+- `image-pin.json` — reviewed digest consumed by the Integration workflow.
+  The image-build workflow updates this file through a pull request after a
+  verified publish; the file is excluded from image-build path triggers to
+  prevent a pin-update loop.
 
 ## Image
 
 Published to `ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci`
 by `.github/workflows/build-browser-ci-image.yml`.
+
+The workflow has three permission-separated jobs:
+
+- `build` — no package write permission; builds and runs the full Phase 0
+  smoke path under `--network=none`.
+- `publish` — the only job with `packages: write`; pushes the verified image
+  to GHCR and pull-verifies the digest.
+- `update-pin` — the only job with `contents: write` and
+  `pull-requests: write`; opens or updates the reviewed `image-pin.json` PR.
 
 ## Runtime contract
 
@@ -30,5 +43,6 @@ container is invoked with:
   `PIP_FIND_LINKS=/opt/ijt-browser-ci/pip-wheelhouse`,
   `PIP_CACHE_DIR=...`, `SKIP_VENV_INSTALL=1`, plus the `GITHUB_*` whitelist.
 
-PR A (this PR) introduces only the image build and publish path. PR B will
-wire the image into `integration.yml`.
+Local Web E2E remains native. Neither the root runner nor the Web Client
+runner reads `IJT_BROWSER_CI_IMAGE`; the owned image is wired only in the
+GitHub Actions Integration workflow.

--- a/.github/docker/ijt-browser-ci/image-pin.json
+++ b/.github/docker/ijt-browser-ci/image-pin.json
@@ -7,5 +7,5 @@
   "image_revision": "3768a248",
   "image_created": "2026-05-13T20:39:23Z",
   "image_workflow_run": "https://github.com/umati/UA-for-Industrial-Joining-Technologies/actions/runs/25824684520",
-  "_comment": "Single source of truth for the IJT Browser CI image consumed by integration.yml live-webclient-browser. IJT_BROWSER_CI_IMAGE is constructed at runtime as image@digest. Refresh procedure: when a new image is published, copy the digest from the Publish to GHCR job summary into this file. The workflow MUST fail fast if digest does not match ^sha256:[0-9a-f]{64}$."
+  "_comment": "Single source of truth for the IJT Browser CI image consumed by integration.yml live-webclient-browser. IJT_BROWSER_CI_IMAGE is constructed at runtime as image@digest. Refresh procedure: the build-browser-ci-image workflow publishes a verified image, updates this file on the automation/ijt-browser-ci-image-pin branch, and opens or updates a reviewable PR. The workflow MUST fail fast if digest does not match ^sha256:[0-9a-f]{64}$."
 }

--- a/.github/scripts/update_browser_ci_image_pin.py
+++ b/.github/scripts/update_browser_ci_image_pin.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Update the IJT Browser CI image pin after a verified image publish."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IMAGE_RE = re.compile(r"^ghcr\.io/[a-z0-9._/-]+$")
+
+_COMMENT = (
+    "Single source of truth for the IJT Browser CI image consumed by "
+    "integration.yml live-webclient-browser. IJT_BROWSER_CI_IMAGE is "
+    "constructed at runtime as image@digest. Refresh procedure: the "
+    "build-browser-ci-image workflow publishes a verified image, updates this "
+    "file on the automation/ijt-browser-ci-image-pin branch, and opens or "
+    "updates a reviewable PR. The workflow MUST fail fast if digest does not "
+    "match ^sha256:[0-9a-f]{64}$."
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _validate_image(image: str) -> None:
+    if ":" in image.rsplit("/", 1)[-1]:
+        raise ValueError(f"image must not include a floating tag, got {image!r}")
+    if not _IMAGE_RE.fullmatch(image):
+        raise ValueError(f"image must be a lowercase ghcr.io reference, got {image!r}")
+
+
+def _validate_digest(digest: str) -> None:
+    if not _SHA256_RE.fullmatch(digest):
+        raise ValueError(f"digest must match ^sha256:[0-9a-f]{{64}}$, got {digest!r}")
+
+
+def _required_value(source: dict[str, Any], key: str) -> str:
+    value = source.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"missing non-empty {key!r}")
+    return value
+
+
+def build_updated_pin(
+    *,
+    current: dict[str, Any],
+    metadata: dict[str, Any],
+    image: str,
+    digest: str,
+    image_revision: str,
+    image_created: str,
+    image_workflow_run: str,
+) -> dict[str, Any]:
+    """Build the next image-pin.json object from verified publish metadata."""
+    _validate_image(image)
+    _validate_digest(digest)
+    if current.get("image") == image and current.get("digest") == digest:
+        return dict(current)
+
+    updated: dict[str, Any] = {
+        "image": image,
+        "digest": digest,
+        "playwright_version": _required_value(metadata, "playwright_version"),
+        "node_version": _required_value(metadata, "node_version"),
+        "python_version": _required_value(metadata, "python_version"),
+        "image_revision": image_revision,
+        "image_created": image_created,
+        "image_workflow_run": image_workflow_run,
+    }
+
+    base_digests = metadata.get("base_digests")
+    if isinstance(base_digests, dict) and base_digests:
+        updated["base_digests"] = base_digests
+
+    for key, value in current.items():
+        if key not in updated and key != "_comment":
+            updated[key] = value
+
+    updated["_comment"] = _COMMENT
+    return updated
+
+
+def update_pin(
+    *,
+    pin_path: Path,
+    metadata_path: Path,
+    image: str,
+    digest: str,
+    image_revision: str,
+    image_created: str,
+    image_workflow_run: str,
+) -> dict[str, Any]:
+    """Rewrite image-pin.json with the verified publish metadata."""
+    current = _load_json(pin_path)
+    updated = build_updated_pin(
+        current=current,
+        metadata=_load_json(metadata_path),
+        image=image,
+        digest=digest,
+        image_revision=image_revision,
+        image_created=image_created,
+        image_workflow_run=image_workflow_run,
+    )
+    if updated == current:
+        return updated
+    pin_path.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
+    return updated
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pin", type=Path, required=True, help="Path to image-pin.json")
+    parser.add_argument(
+        "--metadata",
+        type=Path,
+        required=True,
+        help="Path to /opt/ijt-browser-ci/metadata.json captured from the image",
+    )
+    parser.add_argument("--image", required=True, help="Lowercase ghcr.io image name")
+    parser.add_argument("--digest", required=True, help="sha256:<64hex> image digest")
+    parser.add_argument("--image-revision", required=True, help="Source git SHA")
+    parser.add_argument("--image-created", required=True, help="UTC creation timestamp")
+    parser.add_argument("--image-workflow-run", required=True, help="Workflow run URL")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    update_pin(
+        pin_path=args.pin,
+        metadata_path=args.metadata,
+        image=args.image,
+        digest=args.digest,
+        image_revision=args.image_revision,
+        image_created=args.image_created,
+        image_workflow_run=args.image_workflow_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build-browser-ci-image.yml
+++ b/.github/workflows/build-browser-ci-image.yml
@@ -4,19 +4,26 @@ name: Build Browser CI Image
 # live-webclient-browser matrix job in .github/workflows/integration.yml.
 # See .github/docker/ijt-browser-ci/README.md for design.
 #
-# PR A scope: build path only. PR B wires the image into integration.yml.
+# image-pin.json is intentionally excluded from path triggers. The update-pin
+# job opens a PR that changes only that file; merging that PR must not publish
+# a new image and create an image-pin update loop.
 #
-# Two-job split:
+# Three-job split:
 #   - build:   loads image locally, runs Phase 0 smoke under the exact
 #              runtime contract. NO packages: write.
 #   - publish: depends on build; only runs when push == true; pushes to GHCR
 #              with packages: write scoped to this job only.
+#   - update-pin: depends on publish; opens/updates a reviewable PR that
+#                 refreshes image-pin.json. contents/pull-requests write are
+#                 scoped to this job only.
 
 on:
   push:
     branches: [main]
     paths:
       - '.github/docker/ijt-browser-ci/**'
+      - '!.github/docker/ijt-browser-ci/image-pin.json'
+      - '.github/scripts/update_browser_ci_image_pin.py'
       - '.github/workflows/build-browser-ci-image.yml'
       - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
       - 'OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json'
@@ -25,6 +32,8 @@ on:
   pull_request:
     paths:
       - '.github/docker/ijt-browser-ci/**'
+      - '!.github/docker/ijt-browser-ci/image-pin.json'
+      - '.github/scripts/update_browser_ci_image_pin.py'
       - '.github/workflows/build-browser-ci-image.yml'
       - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
       - 'OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json'
@@ -42,7 +51,7 @@ on:
         options: [ 'true', 'false' ]
 
 # Workflow-level: read-only. packages: write is granted only on the publish
-# job below.
+# job. contents/pull-requests write are granted only on the update-pin job.
 permissions:
   contents: read
 
@@ -67,6 +76,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
@@ -107,17 +118,21 @@ jobs:
           cache-to: type=gha,scope=ijt-browser-ci,mode=max
 
       - name: Phase 0 smoke - metadata + tool versions
+        env:
+          SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
         run: |
           set -euo pipefail
-          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          IMG="${IMAGE_NAME}:phase0-${SHORT_SHA}"
           docker run --rm --network=none "$IMG" cat /opt/ijt-browser-ci/metadata.json
           docker run --rm --network=none "$IMG" bash -c 'python --version | grep -E "^Python 3\.14\."'
           docker run --rm --network=none "$IMG" bash -c 'node --version | grep -E "^v24\."'
 
       - name: Phase 0 smoke - cache & permissions probe (non-root UID)
+        env:
+          SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
         run: |
           set -euo pipefail
-          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          IMG="${IMAGE_NAME}:phase0-${SHORT_SHA}"
           UID_GID="$(id -u):$(id -g)"
           docker run --rm --network=none --user "$UID_GID" "$IMG" bash -c '
             set -euo pipefail
@@ -135,9 +150,11 @@ jobs:
         # fails this step and PR A. Artifacts are captured for inspection
         # regardless of pass/fail via the always() upload step below.
         id: deep_smoke
+        env:
+          SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
         run: |
           set -euo pipefail
-          IMG="${IMAGE_NAME}:phase0-${{ steps.decide.outputs.short_sha }}"
+          IMG="${IMAGE_NAME}:phase0-${SHORT_SHA}"
           UID_GID="$(id -u):$(id -g)"
           mkdir -p "${GITHUB_WORKSPACE}/.phase0-artifacts"
           chmod 0777 "${GITHUB_WORKSPACE}/.phase0-artifacts"
@@ -218,6 +235,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
@@ -265,9 +284,11 @@ jobs:
       - name: Verify published image by digest (pull + offline smoke)
         # Proves GHCR pull permission AND that the digest is usable as
         # IJT_BROWSER_CI_IMAGE for PR B. Hard gate.
+        env:
+          PUBLISHED_DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           set -euo pipefail
-          REF="${IMAGE_NAME}@${{ steps.push.outputs.digest }}"
+          REF="${IMAGE_NAME}@${PUBLISHED_DIGEST}"
           echo "Pulling $REF ..."
           docker pull "$REF"
           docker run --rm --network=none "$REF" cat /opt/ijt-browser-ci/metadata.json
@@ -275,6 +296,9 @@ jobs:
           docker run --rm --network=none "$REF" bash -c 'node --version | grep -E "^v24\."'
 
       - name: Job summary
+        env:
+          PUBLISHED_DIGEST: ${{ steps.push.outputs.digest }}
+          PUBLISHED_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           set -euo pipefail
           {
@@ -282,12 +306,153 @@ jobs:
             echo ""
             echo "- Tags:"
             echo '```'
-            echo "${{ steps.meta.outputs.tags }}"
+            echo "${PUBLISHED_TAGS}"
             echo '```'
-            echo "- Digest: \`${{ steps.push.outputs.digest }}\`"
+            echo "- Digest: \`${PUBLISHED_DIGEST}\`"
             echo ""
-            echo "_PR B can pin (paste into \`integration.yml\` or \`image-pin.json\`):_"
+            echo "_The update-pin job opens or updates a reviewed \`image-pin.json\` PR for:_"
             echo '```'
-            echo "${IMAGE_NAME}@${{ steps.push.outputs.digest }}"
+            echo "${IMAGE_NAME}@${PUBLISHED_DIGEST}"
             echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  update-pin:
+    name: Open image-pin update PR
+    needs: publish
+    if: needs.publish.outputs.digest != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: read
+    env:
+      PIN_BRANCH: automation/ijt-browser-ci-image-pin
+      PIN_PATH: .github/docker/ijt-browser-ci/image-pin.json
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Log in to GHCR for metadata readback
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Capture metadata from published digest
+        env:
+          PUBLISHED_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          REF="${IMAGE_NAME}@${PUBLISHED_DIGEST}"
+          docker pull "$REF"
+          docker run --rm --network=none "$REF" \
+            cat /opt/ijt-browser-ci/metadata.json > "${RUNNER_TEMP}/ijt-browser-ci-metadata.json"
+          cat "${RUNNER_TEMP}/ijt-browser-ci-metadata.json"
+
+      - name: Update image-pin.json
+        env:
+          PUBLISHED_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          python .github/scripts/update_browser_ci_image_pin.py \
+            --pin "$PIN_PATH" \
+            --metadata "${RUNNER_TEMP}/ijt-browser-ci-metadata.json" \
+            --image "$IMAGE_NAME" \
+            --digest "$PUBLISHED_DIGEST" \
+            --image-revision "$GITHUB_SHA" \
+            --image-created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --image-workflow-run "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          python -m json.tool "$PIN_PATH" > /dev/null
+
+      - name: Open or update image-pin PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISHED_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- "$PIN_PATH"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "image-pin.json already points at ${PUBLISHED_DIGEST}; no PR needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git checkout -B "$PIN_BRANCH"
+          git add "$PIN_PATH"
+          git commit -m "Update IJT Browser CI image pin" \
+            -m "1. Point image-pin.json at the verified GHCR digest published by this workflow." \
+            -m "2. Keep the browser Integration job on a reviewed digest instead of a floating tag."
+          # This automation branch is single-writer and represents the newest
+          # verified digest. Force-with-lease intentionally supersedes an older
+          # open pin PR if a later image publishes before review completes.
+          git fetch origin "${PIN_BRANCH}:refs/remotes/origin/${PIN_BRANCH}" || true
+          git push --force-with-lease "origin" "HEAD:refs/heads/${PIN_BRANCH}"
+
+          body_file="${RUNNER_TEMP}/image-pin-pr.md"
+          cat > "$body_file" <<EOF
+          ## IJT Browser CI image pin update
+
+          This PR was opened by \`.github/workflows/build-browser-ci-image.yml\` after a verified image publish.
+
+          - Published digest: \`${IMAGE_NAME}@${PUBLISHED_DIGEST}\`
+          - Source revision: \`${GITHUB_SHA}\`
+          - Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          The build workflow already performed:
+
+          - Phase 0 smoke under \`--network=none\`
+          - GHCR digest publish
+          - Pull-verify of the published digest
+
+          Note on CI checks: PRs opened by GITHUB_TOKEN do not trigger Integration, CodeQL, pre-commit, actionlint, zizmor, or workflow-policy-guard on the PR itself. The new digest has already been validated by this workflow's Phase 0 smoke under \`--network=none\` and publish-job digest pull-verify.
+
+          To run the full Integration matrix against this exact pin PR, close and reopen the PR or push an empty commit as a user.
+
+          Review focus: \`.github/docker/ijt-browser-ci/image-pin.json\` only.
+          EOF
+
+          existing_pr="$(gh pr list --state open --base main --head "$PIN_BRANCH" --json number --jq '.[0].number // empty')"
+          if [[ -n "$existing_pr" ]]; then
+            gh pr edit "$existing_pr" \
+              --title "Update IJT Browser CI image pin" \
+              --body-file "$body_file"
+            echo "pr=${existing_pr}" >> "$GITHUB_OUTPUT"
+          else
+            pr_url="$(gh pr create \
+              --base main \
+              --head "$PIN_BRANCH" \
+              --title "Update IJT Browser CI image pin" \
+              --body-file "$body_file")"
+            echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Job summary
+        if: always()
+        env:
+          UPDATED: ${{ steps.pr.outputs.changed }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+          PUBLISHED_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## IJT Browser CI image - Pin update"
+            echo ""
+            echo "- Published digest: \`${PUBLISHED_DIGEST}\`"
+            echo "- image-pin.json changed: \`${UPDATED:-unknown}\`"
+            if [[ -n "${PR_NUMBER:-}" ]]; then
+              echo "- Existing PR updated: #${PR_NUMBER}"
+            fi
+            if [[ -n "${PR_URL:-}" ]]; then
+              echo "- New PR opened: ${PR_URL}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/tests/test_image_pin.py
+++ b/tests/test_image_pin.py
@@ -8,6 +8,7 @@ syntax/regex failure on Linux runners).
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import re
 import shutil
@@ -18,6 +19,8 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PIN_PATH = _REPO_ROOT / ".github" / "docker" / "ijt-browser-ci" / "image-pin.json"
+_PIN_UPDATE_SCRIPT = _REPO_ROOT / ".github" / "scripts" / "update_browser_ci_image_pin.py"
+_IMAGE_BUILD_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "build-browser-ci-image.yml"
 
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _DIGEST_REF_SUFFIX_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
@@ -193,3 +196,193 @@ def test_local_web_e2e_does_not_require_docker_or_ghcr() -> None:
             "`@playwright/test` version is the single source of truth for the "
             "local browser bundle. CI image references belong in the workflow."
         )
+
+
+# ---------------------------------------------------------------------------
+# Drift-guard automation contracts
+# ---------------------------------------------------------------------------
+
+
+def _load_pin_update_module():
+    spec = importlib.util.spec_from_file_location("update_browser_ci_image_pin", _PIN_UPDATE_SCRIPT)
+    assert spec and spec.loader, f"unable to import {_PIN_UPDATE_SCRIPT}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_update_browser_ci_image_pin_script_writes_verified_publish_metadata() -> None:
+    """The updater must produce a reviewed pin from image metadata, not prose."""
+    module = _load_pin_update_module()
+    updated = module.build_updated_pin(
+        current={
+            "image": "ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci",
+            "digest": "sha256:" + "0" * 64,
+            "playwright_version": "1.60.0",
+            "node_version": "24.x",
+            "python_version": "3.14.x",
+            "image_revision": "old",
+            "image_created": "old",
+            "image_workflow_run": "old",
+            "custom_audit_field": "preserved",
+            "_comment": "old manual comment",
+        },
+        metadata={
+            "playwright_version": "1.60.0",
+            "node_version": "v24.11.1",
+            "python_version": "Python 3.14.0",
+            "base_digests": {
+                "ubuntu": "sha256:" + "a" * 64,
+                "python": "sha256:" + "b" * 64,
+                "node": "sha256:" + "c" * 64,
+            },
+        },
+        image="ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci",
+        digest="sha256:" + "1" * 64,
+        image_revision="abc1234",
+        image_created="2026-05-13T22:00:00Z",
+        image_workflow_run=(
+            "https://github.com/umati/UA-for-Industrial-Joining-Technologies/actions/runs/1"
+        ),
+    )
+
+    assert updated["digest"] == "sha256:" + "1" * 64
+    assert updated["node_version"] == "v24.11.1"
+    assert updated["python_version"] == "Python 3.14.0"
+    assert updated["base_digests"]["ubuntu"] == "sha256:" + "a" * 64
+    assert updated["custom_audit_field"] == "preserved"
+    assert "opens or updates a reviewable PR" in updated["_comment"]
+
+
+def test_update_browser_ci_image_pin_script_keeps_current_pin_when_digest_matches() -> None:
+    """A scheduled rebuild with the same digest must not churn image-pin PRs."""
+    module = _load_pin_update_module()
+    current = {
+        "image": "ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci",
+        "digest": "sha256:" + "1" * 64,
+        "playwright_version": "1.60.0",
+        "node_version": "24.x",
+        "python_version": "3.14.x",
+        "image_revision": "old",
+        "image_created": "old",
+        "image_workflow_run": "old",
+        "_comment": "already reviewed",
+    }
+
+    updated = module.build_updated_pin(
+        current=current,
+        metadata={
+            "playwright_version": "1.60.0",
+            "node_version": "v24.11.1",
+            "python_version": "Python 3.14.0",
+        },
+        image=current["image"],
+        digest=current["digest"],
+        image_revision="new",
+        image_created="2026-05-13T23:00:00Z",
+        image_workflow_run="https://github.com/example/repo/actions/runs/2",
+    )
+
+    assert updated == current
+
+
+@pytest.mark.parametrize(
+    ("image", "digest", "message"),
+    [
+        (
+            "ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci:latest",
+            "sha256:" + "1" * 64,
+            "floating tag",
+        ),
+        (
+            "docker.io/umati/ijt-browser-ci",
+            "sha256:" + "1" * 64,
+            "lowercase ghcr.io",
+        ),
+        (
+            "ghcr.io/umati/ua-for-industrial-joining-technologies/ijt-browser-ci",
+            "sha256:not-a-digest",
+            "sha256",
+        ),
+    ],
+)
+def test_update_browser_ci_image_pin_script_rejects_unsafe_references(
+    image: str,
+    digest: str,
+    message: str,
+) -> None:
+    module = _load_pin_update_module()
+
+    with pytest.raises(ValueError, match=message):
+        module.build_updated_pin(
+            current={},
+            metadata={
+                "playwright_version": "1.60.0",
+                "node_version": "v24.11.1",
+                "python_version": "Python 3.14.0",
+            },
+            image=image,
+            digest=digest,
+            image_revision="abc1234",
+            image_created="2026-05-13T22:00:00Z",
+            image_workflow_run="https://github.com/example/repo/actions/runs/1",
+        )
+
+
+def test_build_browser_ci_image_workflow_opens_reviewed_pin_pr_without_loop() -> None:
+    """Pin refresh must be automatic but still reviewable and non-self-triggering."""
+    import yaml
+
+    workflow = yaml.safe_load(_IMAGE_BUILD_WORKFLOW.read_text(encoding="utf-8"))
+    triggers = workflow.get("on", workflow.get(True, {}))
+    for event_name in ("push", "pull_request"):
+        paths = triggers[event_name]["paths"]
+        docker_glob_index = paths.index(".github/docker/ijt-browser-ci/**")
+        pin_exclude_index = paths.index("!.github/docker/ijt-browser-ci/image-pin.json")
+        assert docker_glob_index < pin_exclude_index, (
+            "image-pin.json must be excluded after the docker directory include; "
+            "otherwise the automation branch can publish a fresh image and loop."
+        )
+
+    assert workflow["permissions"] == {"contents": "read"}
+    jobs = workflow["jobs"]
+    assert jobs["publish"]["permissions"] == {
+        "contents": "read",
+        "packages": "write",
+        "id-token": "write",
+    }
+
+    update_pin_job = jobs["update-pin"]
+    assert update_pin_job["needs"] == "publish"
+    assert update_pin_job["permissions"] == {
+        "contents": "write",
+        "pull-requests": "write",
+        "packages": "read",
+    }
+    assert update_pin_job["env"]["PIN_BRANCH"] == "automation/ijt-browser-ci-image-pin"
+    assert update_pin_job["env"]["PIN_PATH"] == ".github/docker/ijt-browser-ci/image-pin.json"
+
+    step_names = [step.get("name", "") for step in update_pin_job["steps"]]
+    assert "Capture metadata from published digest" in step_names
+    assert "Update image-pin.json" in step_names
+    assert "Open or update image-pin PR" in step_names
+
+    update_step = next(
+        step for step in update_pin_job["steps"] if step.get("name") == "Update image-pin.json"
+    )
+    assert ".github/scripts/update_browser_ci_image_pin.py" in update_step["run"]
+    assert "--metadata" in update_step["run"]
+    assert '--digest "$PUBLISHED_DIGEST"' in update_step["run"]
+
+    pr_step = next(
+        step
+        for step in update_pin_job["steps"]
+        if step.get("name") == "Open or update image-pin PR"
+    )
+    pr_body = pr_step["run"]
+    assert "git push --force-with-lease" in pr_body
+    assert "gh pr list" in pr_body
+    assert "gh pr edit" in pr_body
+    assert "gh pr create" in pr_body
+    assert "Review focus:" in pr_body
+    assert ".github/docker/ijt-browser-ci/image-pin.json" in pr_body


### PR DESCRIPTION
## Summary

Automates the IJT Browser CI image pin via a reviewed PR opened by the existing image-build workflow after each verified publish. Eliminates the manual digest-edit step that was the last remaining gap after PR A (image build) and PR B (image wiring).

## What changes

1. New `update-pin` job in `.github/workflows/build-browser-ci-image.yml`. Depends on `publish`. Pulls the just-published digest, reads `/opt/ijt-browser-ci/metadata.json` under `--network=none`, rewrites `image-pin.json` via a new helper script, force-pushes the `automation/ijt-browser-ci-image-pin` branch, and opens (or updates) a reviewable PR scoped to `image-pin.json` only.
2. New helper `.github/scripts/update_browser_ci_image_pin.py` (Python). Validates the image reference is lowercase `ghcr.io/...` with no floating tag; validates the digest matches `^sha256:[0-9a-f]{64}$`; preserves any custom audit fields on the existing pin; short-circuits (no rewrite, no PR) when the digest already matches so scheduled rebuilds with unchanged content do not churn PRs.
3. Loop prevention. `image-pin.json` is excluded from the `push` and `pull_request` path triggers of `build-browser-ci-image.yml` (`!.github/docker/ijt-browser-ci/image-pin.json` placed after `.github/docker/ijt-browser-ci/**`). Merging the auto-PR therefore cannot re-trigger the image build and cannot create a self-update loop.
4. Permissions boundary tightened. Workflow-level `contents: read` only. `packages: write` scoped to the `publish` job. `contents: write` and `pull-requests: write` scoped to the `update-pin` job. `build` stays read-only.
5. PR-body honesty about CI-trigger semantics. The auto-PR body explicitly states that `GITHUB_TOKEN`-opened PRs do not trigger Integration, CodeQL, pre-commit, actionlint, zizmor, or workflow-policy-guard on the PR itself; describes the upstream trust chain (Phase 0 smoke under `--network=none` plus publish-job digest pull-verify); and gives the escape hatch (close and reopen, or push an empty commit as a user).
6. Force-with-lease intent documented. Inline comment near `git push --force-with-lease` makes clear the automation branch is single-writer and intentionally supersedes any older open pin PR when a newer verified digest exists.
7. Contract tests in `tests/test_image_pin.py` covering: the helper script produces a valid pin from verified publish metadata; the same-digest short-circuit returns the existing pin unchanged; the helper rejects unsafe references (floating tags, non-ghcr.io images, malformed digests); the workflow shape (path-trigger ordering for loop prevention, per-job permission scopes, branch name, pin path, all three update-pin step names, and presence of `git push --force-with-lease`, `gh pr list/edit/create`, `Review focus:` in the PR-open step).

## Why

After PR A and PR B merged on `main` (commit `00138113`), the only remaining manual step in the image lifecycle was editing `.github/docker/ijt-browser-ci/image-pin.json` by hand whenever the image was rebuilt. That was the agreed deferral point — keep PR A's permission surface minimal, prove the manual path first, then ship the automation in its own reviewable change. This PR closes that gap.

## Trust chain

The auto-PR proposes only `image-pin.json`. The digest in that PR has already been:

- Built by the `build` job and exercised under the full Phase 0 smoke including `web-client-e2e-regression` against `--network=none` with a non-root UID.
- Pushed to GHCR by the `publish` job with `provenance: true` and `sbom: true`.
- Pulled and re-verified by the `publish` job (`docker pull <image>@<digest>` followed by metadata + python + node version assertions under `--network=none`).

The reviewer's job on the auto-PR is therefore to confirm that `image-pin.json` is what the workflow run summary advertised, not to re-run the matrix.

## Loop-prevention verification

`paths.index(".github/docker/ijt-browser-ci/**")` is asserted to be less than `paths.index("!.github/docker/ijt-browser-ci/image-pin.json")` for both `push` and `pull_request` triggers. Test: `test_build_browser_ci_image_workflow_opens_reviewed_pin_pr_without_loop`.

## Validation

- `pytest tests/test_image_pin.py tests/test_root_runner.py -q` → 87 passed locally.
- `ruff check` clean on changed files.
- `actionlint .github/workflows/build-browser-ci-image.yml` clean.
- `zizmor .github/workflows/build-browser-ci-image.yml` no findings.
- Pre-commit (full hook set including check-yaml, check-json, mixed-line-ending, ruff/ruff-format, workflow-policy-guard, validate-github-workflows, zizmor, actionlint) passed on the commit.

## Out of scope

- This PR does not change the `live-webclient-browser` job in `integration.yml`. PR B already wired that job to consume the digest from `image-pin.json`.
- No new secrets or PATs are introduced. The auto-PR uses only `GITHUB_TOKEN` with per-job-scoped permissions; the documented trade-off is that CI on the auto-PR is opt-in via the escape hatch.

## After merge

1. The next push to `main` that touches the image (e.g., `Dockerfile`, `package-lock.json`, `requirements.txt`, the build workflow itself, or the updater script) will publish a new digest and automatically open a pin-update PR.
2. The weekly Monday 05:17 UTC schedule will also rebuild; in the common case of unchanged source, the digest matches and no PR is opened (verified by the same-digest short-circuit test).
3. A reviewer (Mohit) accepts or rejects the pin-update PR; on accept, `image-pin.json` updates on `main` and the next `integration.yml` run picks up the new digest automatically.
