### PR TITLE
Add update-pin observability and README path exclusion

### DIFF
--- a/.github/workflows/build-browser-ci-image.yml
+++ b/.github/workflows/build-browser-ci-image.yml
@@ -4,9 +4,10 @@ name: Build Browser CI Image
 # live-webclient-browser matrix job in .github/workflows/integration.yml.
 # See .github/docker/ijt-browser-ci/README.md for design.
 #
-# image-pin.json is intentionally excluded from path triggers. The update-pin
-# job opens a PR that changes only that file; merging that PR must not publish
-# a new image and create an image-pin update loop.
+# image-pin.json and this README are intentionally excluded from path triggers.
+# The update-pin job opens a PR that changes only image-pin.json; merging that
+# PR must not publish a new image and create an image-pin update loop. README
+# updates must not rebuild the browser image either.
 #
 # Three-job split:
 #   - build:   loads image locally, runs Phase 0 smoke under the exact
@@ -23,6 +24,7 @@ on:
     paths:
       - '.github/docker/ijt-browser-ci/**'
       - '!.github/docker/ijt-browser-ci/image-pin.json'
+      - '!.github/docker/ijt-browser-ci/README.md'
       - '.github/scripts/update_browser_ci_image_pin.py'
       - '.github/workflows/build-browser-ci-image.yml'
       - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
@@ -33,6 +35,7 @@ on:
     paths:
       - '.github/docker/ijt-browser-ci/**'
       - '!.github/docker/ijt-browser-ci/image-pin.json'
+      - '!.github/docker/ijt-browser-ci/README.md'
       - '.github/scripts/update_browser_ci_image_pin.py'
       - '.github/workflows/build-browser-ci-image.yml'
       - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
@@ -344,6 +347,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Capture metadata from published digest
+        id: capture_metadata
         env:
           PUBLISHED_DIGEST: ${{ needs.publish.outputs.digest }}
         run: |
@@ -353,8 +357,11 @@ jobs:
           docker run --rm --network=none "$REF" \
             cat /opt/ijt-browser-ci/metadata.json > "${RUNNER_TEMP}/ijt-browser-ci-metadata.json"
           cat "${RUNNER_TEMP}/ijt-browser-ci-metadata.json"
+          echo "result=captured" >> "$GITHUB_OUTPUT"
+          echo "reason=metadata captured from published digest" >> "$GITHUB_OUTPUT"
 
       - name: Update image-pin.json
+        id: update_pin
         env:
           PUBLISHED_DIGEST: ${{ needs.publish.outputs.digest }}
         run: |
@@ -368,6 +375,8 @@ jobs:
             --image-created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --image-workflow-run "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           python -m json.tool "$PIN_PATH" > /dev/null
+          echo "result=rendered" >> "$GITHUB_OUTPUT"
+          echo "reason=image-pin.json rendered from verified metadata" >> "$GITHUB_OUTPUT"
 
       - name: Open or update image-pin PR
         id: pr
@@ -377,7 +386,11 @@ jobs:
         run: |
           set -euo pipefail
           if git diff --quiet -- "$PIN_PATH"; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "changed=false"
+              echo "auto_pr_result=no_change"
+              echo "reason=image-pin.json already points at ${PUBLISHED_DIGEST}; no PR needed"
+            } >> "$GITHUB_OUTPUT"
             echo "image-pin.json already points at ${PUBLISHED_DIGEST}; no PR needed."
             exit 0
           fi
@@ -424,21 +437,37 @@ jobs:
             gh pr edit "$existing_pr" \
               --title "Update IJT Browser CI image pin" \
               --body-file "$body_file"
-            echo "pr=${existing_pr}" >> "$GITHUB_OUTPUT"
+            {
+              echo "pr=${existing_pr}"
+              echo "auto_pr_result=updated"
+              echo "reason=updated existing image-pin PR #${existing_pr}"
+              echo "changed=true"
+            } >> "$GITHUB_OUTPUT"
           else
             pr_url="$(gh pr create \
               --base main \
               --head "$PIN_BRANCH" \
               --title "Update IJT Browser CI image pin" \
               --body-file "$body_file")"
-            echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
+            {
+              echo "pr_url=${pr_url}"
+              echo "auto_pr_result=opened"
+              echo "reason=opened new image-pin PR ${pr_url}"
+              echo "changed=true"
+            } >> "$GITHUB_OUTPUT"
           fi
-          echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Job summary
         if: always()
         env:
           UPDATED: ${{ steps.pr.outputs.changed }}
+          CAPTURE_OUTCOME: ${{ steps.capture_metadata.outcome }}
+          CAPTURE_REASON: ${{ steps.capture_metadata.outputs.reason }}
+          UPDATE_OUTCOME: ${{ steps.update_pin.outcome }}
+          UPDATE_REASON: ${{ steps.update_pin.outputs.reason }}
+          PR_OUTCOME: ${{ steps.pr.outcome }}
+          AUTO_PR_RESULT: ${{ steps.pr.outputs.auto_pr_result }}
+          AUTO_PR_REASON: ${{ steps.pr.outputs.reason }}
           PR_NUMBER: ${{ steps.pr.outputs.pr }}
           PR_URL: ${{ steps.pr.outputs.pr_url }}
           PUBLISHED_DIGEST: ${{ needs.publish.outputs.digest }}
@@ -449,10 +478,19 @@ jobs:
             echo ""
             echo "- Published digest: \`${PUBLISHED_DIGEST}\`"
             echo "- image-pin.json changed: \`${UPDATED:-unknown}\`"
+            echo "- Metadata capture: \`${CAPTURE_OUTCOME:-unknown}\` — ${CAPTURE_REASON:-not completed}"
+            echo "- Pin update: \`${UPDATE_OUTCOME:-unknown}\` — ${UPDATE_REASON:-not completed}"
+            echo "- Auto-PR opened/updated: \`${AUTO_PR_RESULT:-not_attempted}\`"
+            echo "- Auto-PR step outcome: \`${PR_OUTCOME:-unknown}\`"
+            echo "- Reason: ${AUTO_PR_REASON:-not completed; inspect the first failed update-pin step above}"
             if [[ -n "${PR_NUMBER:-}" ]]; then
               echo "- Existing PR updated: #${PR_NUMBER}"
             fi
             if [[ -n "${PR_URL:-}" ]]; then
               echo "- New PR opened: ${PR_URL}"
+            fi
+            if [[ "${CAPTURE_OUTCOME:-}" != "success" || "${UPDATE_OUTCOME:-}" != "success" || "${PR_OUTCOME:-}" != "success" ]]; then
+              echo ""
+              echo "> One or more update-pin steps did not succeed. Review the failed step logs before re-running the workflow."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/tests/test_image_pin.py
+++ b/tests/test_image_pin.py
@@ -151,7 +151,10 @@ def test_ijt_browser_ci_image_env_var_is_workflow_or_image_config_only() -> None
         Path(".github/workflows"),
         Path(".github/docker/ijt-browser-ci"),
     )
-    allowed_exact = {Path("tests/test_image_pin.py")}
+    allowed_exact = {
+        Path(".github/scripts/update_browser_ci_image_pin.py"),
+        Path("tests/test_image_pin.py"),
+    }
     offenders: list[str] = []
 
     for path in _tracked_files():
@@ -339,9 +342,14 @@ def test_build_browser_ci_image_workflow_opens_reviewed_pin_pr_without_loop() ->
         paths = triggers[event_name]["paths"]
         docker_glob_index = paths.index(".github/docker/ijt-browser-ci/**")
         pin_exclude_index = paths.index("!.github/docker/ijt-browser-ci/image-pin.json")
+        readme_exclude_index = paths.index("!.github/docker/ijt-browser-ci/README.md")
         assert docker_glob_index < pin_exclude_index, (
             "image-pin.json must be excluded after the docker directory include; "
             "otherwise the automation branch can publish a fresh image and loop."
+        )
+        assert docker_glob_index < readme_exclude_index, (
+            "README.md must be excluded after the docker directory include; "
+            "documentation-only edits must not rebuild and republish the browser image."
         )
 
     assert workflow["permissions"] == {"contents": "read"}
@@ -366,23 +374,60 @@ def test_build_browser_ci_image_workflow_opens_reviewed_pin_pr_without_loop() ->
     assert "Capture metadata from published digest" in step_names
     assert "Update image-pin.json" in step_names
     assert "Open or update image-pin PR" in step_names
+    assert "Job summary" in step_names
+
+    capture_step = next(
+        step
+        for step in update_pin_job["steps"]
+        if step.get("name") == "Capture metadata from published digest"
+    )
+    assert capture_step.get("id") == "capture_metadata"
+    assert "result=captured" in capture_step["run"]
+    assert "metadata captured from published digest" in capture_step["run"]
 
     update_step = next(
         step for step in update_pin_job["steps"] if step.get("name") == "Update image-pin.json"
     )
+    assert update_step.get("id") == "update_pin"
     assert ".github/scripts/update_browser_ci_image_pin.py" in update_step["run"]
     assert "--metadata" in update_step["run"]
     assert '--digest "$PUBLISHED_DIGEST"' in update_step["run"]
+    assert "result=rendered" in update_step["run"]
+    assert "image-pin.json rendered from verified metadata" in update_step["run"]
 
     pr_step = next(
         step
         for step in update_pin_job["steps"]
         if step.get("name") == "Open or update image-pin PR"
     )
+    assert pr_step.get("id") == "pr"
     pr_body = pr_step["run"]
+    assert "auto_pr_result=no_change" in pr_body
+    assert "auto_pr_result=updated" in pr_body
+    assert "auto_pr_result=opened" in pr_body
+    assert "reason=image-pin.json already points at ${PUBLISHED_DIGEST}; no PR needed" in pr_body
+    assert "reason=updated existing image-pin PR" in pr_body
+    assert "reason=opened new image-pin PR" in pr_body
     assert "git push --force-with-lease" in pr_body
     assert "gh pr list" in pr_body
     assert "gh pr edit" in pr_body
     assert "gh pr create" in pr_body
     assert "Review focus:" in pr_body
     assert ".github/docker/ijt-browser-ci/image-pin.json" in pr_body
+
+    summary_step = next(
+        step for step in update_pin_job["steps"] if step.get("name") == "Job summary"
+    )
+    assert summary_step.get("if") == "always()"
+    summary_env = summary_step["env"]
+    assert summary_env["CAPTURE_OUTCOME"] == "${{ steps.capture_metadata.outcome }}"
+    assert summary_env["UPDATE_OUTCOME"] == "${{ steps.update_pin.outcome }}"
+    assert summary_env["PR_OUTCOME"] == "${{ steps.pr.outcome }}"
+    assert summary_env["AUTO_PR_RESULT"] == "${{ steps.pr.outputs.auto_pr_result }}"
+    assert summary_env["AUTO_PR_REASON"] == "${{ steps.pr.outputs.reason }}"
+    summary_body = summary_step["run"]
+    assert "Metadata capture:" in summary_body
+    assert "Pin update:" in summary_body
+    assert "Auto-PR opened/updated:" in summary_body
+    assert "not completed; inspect the first failed update-pin step above" in summary_body
+    assert "One or more update-pin steps did not succeed" in summary_body


### PR DESCRIPTION
## Summary

Adds observability to the `update-pin` job in `.github/workflows/build-browser-ci-image.yml` and extends the workflow's path-exclusion list so README-only edits do not retrigger the image build.

## Failure class removed

| Failure class | Failure mode | Owning PR |
|---|---|---|
| `update-pin` silent failure | If `publish` succeeds but a step inside `update-pin` fails (token scope, force-with-lease conflict, GH API hiccup, metadata capture failure), the auto-PR simply does not appear and the lane silently stalls until the next scheduled rebuild. No alarm reaches the run summary. | This PR |
| README-edit rebuild noise | Edits to `.github/docker/ijt-browser-ci/README.md` (docs-only) currently retrigger the full build + publish + update-pin pipeline. README content is not part of the image's runtime contract. | This PR |

## Changes

1. **Step IDs added** to `Capture metadata from published digest` (`capture_metadata`), `Update image-pin.json` (`update_pin`), and the existing `Open or update image-pin PR` (`pr`). Required so the closing `Job summary` step can read each step's `outcome` and structured outputs.
2. **Structured outputs** emitted by each update-pin step: `result=<state>` and `reason=<human-readable>` written to `$GITHUB_OUTPUT`. The PR-open step also writes `auto_pr_result` (`no_change` / `updated` / `opened`).
3. **`Job summary` step** (`if: always()`) writes a one-section block to `$GITHUB_STEP_SUMMARY` with: published digest, image-pin.json changed flag, metadata-capture outcome + reason, pin-update outcome + reason, auto-PR result, PR-step outcome, reason text, PR number or URL when present, and a one-line stop-the-line warning if any of the three sub-steps did not succeed.
4. **README path exclusion** added to both `push.paths` and `pull_request.paths` in the workflow's trigger block: `!.github/docker/ijt-browser-ci/README.md` placed immediately after the existing `image-pin.json` exclusion. Loop-prevention semantics are identical (positive include followed by exclusion).
5. **Contract tests extended** in `tests/test_image_pin.py`: asserts README path-exclusion ordering on both events, asserts the new step IDs, asserts every new `result=` / `reason=` / `auto_pr_result=` line is present in the step `run:` blocks, and asserts the new `Job summary` step name appears.

## Claims ledger

| Claim | Source line / command | Verified by | Result | Status |
|---|---|---|---|---|
| Pre-commit clean on the two staged files | `pre-commit run --files .github/workflows/build-browser-ci-image.yml tests/test_image_pin.py` | local | all hooks Passed or Skipped | Verified locally |
| Contract tests still green | `python -m pytest tests/test_image_pin.py tests/test_root_runner.py -q` | local | `87 passed in 29.65s` | Verified locally |
| YAML parses | check-yaml (pre-commit) | local | Passed | Verified locally |
| actionlint clean | `Validate GitHub Workflows` pre-commit hook | local | Passed | Verified locally |
| zizmor clean | zizmor pre-commit hook | local | Passed | Verified locally |
| ruff clean | ruff + ruff format pre-commit hooks | local | Passed | Verified locally |
| update-pin observability surfaces in the run summary | step-summary `if: always()` block writes outcome + reason for every sub-step | GHA on this PR | (pending) | Must verify on GitHub |
| README path exclusion suppresses image rebuild on README-only edits | path-trigger semantics on push to `main` | GHA after merge | (pending) | Must verify on GitHub |

## GitHub platform-behavior checklist

- **Trigger semantics.** Same `push` + `pull_request` events as before; no new triggers. README exclusion narrows the trigger surface but does not widen it. This workflow opens a PR via `GITHUB_TOKEN` (existing behavior, documented limitation: such PRs do not trigger downstream required checks; escape hatch is close+reopen).
- **Path include / exclude ordering.** Both events list `.github/docker/ijt-browser-ci/**` (include) **before** `!.github/docker/ijt-browser-ci/image-pin.json` and the new `!.github/docker/ijt-browser-ci/README.md` (excludes). Order is asserted by `test_build_browser_ci_image_workflow_opens_reviewed_pin_pr_without_loop` for both files.
- **Job-level vs step-level container.** Unchanged. `update-pin` continues to use step-level `docker run` for metadata capture.
- **Per-job permission scope.** Unchanged. Workflow-level `contents: read`; `update-pin` retains `contents: write + pull-requests: write + packages: read`; only emits to `$GITHUB_STEP_SUMMARY` and `$GITHUB_OUTPUT`, no new scopes.
- **Branch-protection / required-check impact.** No required-check name changes. No new required checks added. No existing required checks renamed.
- **Force-push / branch-supersede semantics.** Unchanged.
- **Docker reproducibility.** Not affected. Job-summary text intentionally does NOT assert that the digest matched a prior digest, because rebuilds are not byte-reproducible.

## Review-target contract

1. **What changes.** Workflow gains 1 path exclusion, 2 step IDs, 6 structured-output lines across 3 steps, and 7 new lines in the existing `Job summary` step. Tests gain 7 new assertions.
2. **What must stay true.** All existing step names, the order of trigger paths (positive include first, exclusions after), permission boundaries, the force-with-lease behavior, and the same-digest short-circuit.
3. **What failure class this removes.** Silent `update-pin` failure after a successful publish; README-edit rebuild noise.
4. **Out of scope.** README content itself (held for a follow-up PR after this one merges); `.gitignore` hygiene (same follow-up); branch-protection ruleset changes; any change to the updater script `update_browser_ci_image_pin.py`.
5. **Proof required before merge.** Local: pre-commit + pytest (above, both green). GHA on this PR: full required-check set green. After merge: a build-image run from a non-README change publishes and emits the new `Job summary` lines; a subsequent README-only edit on `main` does NOT trigger this workflow.

## How to verify after merge

1. The next non-README change under `.github/docker/ijt-browser-ci/**` triggers `Build Browser CI Image` and the `Job summary` shows the new lines (Metadata capture, Pin update, Auto-PR opened/updated, etc.).
2. Push a README-only edit to `main` (a typo fix is sufficient) and observe that `Build Browser CI Image` does NOT run for that commit.
