### PR TITLE
ci(browser): replace GHCR polling with one Integration DAG

### DIFF
--- a/.github/workflows/build-browser-ci-image.yml
+++ b/.github/workflows/build-browser-ci-image.yml
@@ -14,29 +14,19 @@ name: Build Browser CI Image
 #                  NO packages: write.
 #   - publish:     depends on build; only runs when push == true. Main/
 #                  scheduled/manual publishes refresh the reviewed pin path;
-#                  same-repo PRs that change browser image inputs publish a
-#                  PR-scoped source-SHA tag consumed by integration.yml.
+#                  same-repo PRs that change browser image inputs reach us via
+#                  workflow_call from integration.yml and publish a fingerprint-
+#                  keyed cache tag plus a PR-scoped tag for provenance/debug.
+#                  The synchronization path is the workflow_call digest output,
+#                  not a tag lookup.
 #   - offline-e2e: depends on publish and runs the full offline browser
-#                  regression contract. It fails the workflow/required check
-#                  without blocking image publication.
+#                  regression contract. Skipped on the workflow_call path
+#                  because the calling Integration run's live-webclient-browser
+#                  matrix verifies against the same digest.
 
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/docker/ijt-browser-ci/**'
-      - '!.github/docker/ijt-browser-ci/image-pin.json'
-      - '!.github/docker/ijt-browser-ci/README.md'
-      - '.github/scripts/update_browser_ci_image_pin.py'
-      - '.github/scripts/compute_browser_image_fingerprint.py'
-      - '.github/workflows/build-browser-ci-image.yml'
-      - '.dockerignore'
-      - 'constraints.txt'
-      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package.json'
-      - 'OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json'
-      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt'
-      - 'OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt'
-  pull_request:
     paths:
       - '.github/docker/ijt-browser-ci/**'
       - '!.github/docker/ijt-browser-ci/image-pin.json'
@@ -60,6 +50,26 @@ on:
         default: 'false'
         type: choice
         options: [ 'true', 'false' ]
+  # PR path reaches this workflow only via workflow_call from integration.yml's
+  # prepare-browser-image-plan -> build-browser-image chain. That chain decides
+  # whether to invoke us at all (planner short-circuits on pin/cache match) and
+  # passes the expected inputs_fingerprint as an explicit, YAML-visible contract.
+  workflow_call:
+    inputs:
+      expected_fingerprint:
+        description: 'Inputs fingerprint the caller computed; the build step asserts equality and fails fast if drift occurred between caller checkout and this run.'
+        required: true
+        type: string
+    outputs:
+      digest:
+        description: 'Digest of the published image (sha256:<64hex>).'
+        value: ${{ jobs.publish.outputs.digest }}
+      source_sha:
+        description: 'GITHUB_SHA the publish job built from (provenance only, not a runtime trust check).'
+        value: ${{ jobs.build.outputs.source_sha }}
+      inputs_fingerprint:
+        description: 'Inputs fingerprint baked into the published image metadata.'
+        value: ${{ jobs.build.outputs.inputs_fingerprint }}
 
 # Workflow-level: read-only. packages: write is granted only on the publish job.
 permissions:
@@ -103,16 +113,36 @@ jobs:
           python .github/scripts/compute_browser_image_fingerprint.py --format github-output >> "$GITHUB_OUTPUT"
           python .github/scripts/compute_browser_image_fingerprint.py --format json
 
+      - name: Assert caller's expected fingerprint matches this checkout
+        # Runs only on the workflow_call path (integration.yml planner -> build).
+        # Standalone push/schedule/dispatch invocations pass through untouched.
+        # Failure here is a contract violation: the caller computed a fingerprint
+        # at planner time and this build sees a different one, i.e. the source
+        # tree drifted between planner and build. Fail fast with a diagnostic
+        # rather than silently publishing a mismatched image.
+        if: ${{ inputs.expected_fingerprint != '' }}
+        env:
+          EXPECTED_FINGERPRINT: ${{ inputs.expected_fingerprint }}
+          COMPUTED_FINGERPRINT: ${{ steps.fingerprint.outputs.inputs_fingerprint }}
+        run: |
+          set -euo pipefail
+          if [[ "$COMPUTED_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]]; then
+            echo "::error::Browser CI image input fingerprint drifted between planner and build." >&2
+            echo "::error::  expected (planner): ${EXPECTED_FINGERPRINT}" >&2
+            echo "::error::  computed (build):   ${COMPUTED_FINGERPRINT}" >&2
+            echo "::error::  action: rerun integration.yml so the planner recomputes against the current source tree." >&2
+            exit 1
+          fi
+
       - name: Decide whether to push (carry to publish job)
         id: decide
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
           DISPATCH_PUSH: ${{ inputs.push }}
+          EXPECTED_FINGERPRINT: ${{ inputs.expected_fingerprint }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
           set -euo pipefail
           SOURCE_SHA="$GITHUB_SHA"
@@ -120,53 +150,34 @@ jobs:
           PUBLISH_MODE="none"
           PR_IMAGE_TAG=""
           PUSH_OUTPUT="false"
-          browser_image_inputs_changed=false
 
-          if [[ "$EVENT_NAME" == "pull_request" && "$PR_HEAD_REPO" == "$GITHUB_REPOSITORY" ]]; then
-            git fetch --no-tags --depth=1 origin "$PR_BASE_SHA" "$PR_HEAD_SHA"
-            changed_files="$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA")"
-            while IFS= read -r changed; do
-              [[ -n "$changed" ]] || continue
-              case "$changed" in
-                .dockerignore)
-                  browser_image_inputs_changed=true
-                  ;;
-                constraints.txt)
-                  browser_image_inputs_changed=true
-                  ;;
-                OPC_UA_Clients/Release2/IJT_Web_Client/package.json)
-                  browser_image_inputs_changed=true
-                  ;;
-                OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json)
-                  browser_image_inputs_changed=true
-                  ;;
-                OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt)
-                  browser_image_inputs_changed=true
-                  ;;
-                OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt)
-                  browser_image_inputs_changed=true
-                  ;;
-                .github/docker/ijt-browser-ci/image-pin.json)
-                  ;;
-                .github/docker/ijt-browser-ci/README.md)
-                  ;;
-                .github/docker/ijt-browser-ci/*)
-                  browser_image_inputs_changed=true
-                  ;;
-                .github/scripts/update_browser_ci_image_pin.py)
-                  browser_image_inputs_changed=true
-                  ;;
-                .github/scripts/compute_browser_image_fingerprint.py)
-                  browser_image_inputs_changed=true
-                  ;;
-                .github/workflows/build-browser-ci-image.yml)
-                  browser_image_inputs_changed=true
-                  ;;
-              esac
-            done <<< "$changed_files"
-          fi
-
-          if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+          # workflow_call path (called from integration.yml). The planner only
+          # invokes us when a build is actually needed (no pin/cache match), so
+          # we always publish. The publish mode follows the caller's event:
+          # pull_request -> pr-scoped image (consumed by the calling Integration
+          # run via digest output, not by tag polling); main/schedule/dispatch
+          # -> pin-refresh image (operator opens a reviewed image-pin.json PR
+          # afterwards).
+          if [[ -n "$EXPECTED_FINGERPRINT" ]]; then
+            PUSH_OUTPUT="true"
+            if [[ "$EVENT_NAME" == "pull_request" && "$PR_HEAD_REPO" == "$GITHUB_REPOSITORY" ]]; then
+              PUBLISH_MODE="pr"
+              PR_IMAGE_TAG="${IMAGE_NAME}:pr-${PR_NUMBER}-${SHORT_SHA}"
+            elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+              PUBLISH_MODE="pin"
+            elif [[ "$EVENT_NAME" == "schedule" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
+              PUBLISH_MODE="pin"
+            else
+              # Untrusted PR (fork) reaching workflow_call should have been
+              # blocked at the planner; defend in depth here too.
+              echo "::error::workflow_call invoked from unsupported event ($EVENT_NAME, head_repo=$PR_HEAD_REPO)." >&2
+              exit 1
+            fi
+          # Standalone path: push to main, weekly schedule, or manual dispatch.
+          # These refresh the reviewed image-pin.json digest. The pull_request
+          # trigger no longer exists on this workflow; PR builds reach us only
+          # through the workflow_call branch above.
+          elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
             PUSH_OUTPUT="true"
             PUBLISH_MODE="pin"
           elif [[ "$EVENT_NAME" == "schedule" ]]; then
@@ -177,10 +188,6 @@ jobs:
             if [[ "$DISPATCH_PUSH" == "true" ]]; then
               PUBLISH_MODE="pin"
             fi
-          elif [[ "$browser_image_inputs_changed" == "true" ]]; then
-            PUSH_OUTPUT="true"
-            PUBLISH_MODE="pr"
-            PR_IMAGE_TAG="${IMAGE_NAME}:pr-${PR_NUMBER}-${SHORT_SHA}"
           fi
           {
             echo "source_sha=${SOURCE_SHA}"
@@ -248,8 +255,10 @@ jobs:
         # Image-integrity gate only: prove the baked pip wheelhouse, npm cache,
         # Chromium install, and non-root permissions are usable with
         # --network=none. Full browser behavior stays in the post-publish
-        # offline-e2e job so product regressions do not prevent publishing the
-        # PR/SHA image that Integration needs for diagnostics.
+        # offline-e2e job (standalone path) or in the calling Integration
+        # run's live-webclient-browser matrix (workflow_call path), so product
+        # regressions do not prevent publishing the digest those consumers
+        # need.
         env:
           SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
         run: |
@@ -385,9 +394,16 @@ jobs:
           BUILD_SHORT_SHA: ${{ needs.build.outputs.short_sha }}
           PUBLISH_MODE: ${{ needs.build.outputs.publish_mode }}
           PR_IMAGE_TAG: ${{ needs.build.outputs.pr_image_tag }}
+          INPUTS_FINGERPRINT: ${{ needs.build.outputs.inputs_fingerprint }}
         run: |
           set -euo pipefail
           TAGS="${IMAGE_NAME}:sha-${BUILD_SHORT_SHA}"
+          # Fingerprint-keyed tag is the cache identity used by the consumer's
+          # planner. Any future PR/push with the same inputs_fingerprint resolves
+          # this tag to the existing digest and skips building entirely.
+          # build_sha is only provenance; it MUST NOT participate in cache
+          # identity or in the consumer's runtime trust check.
+          TAGS="${TAGS}"$'\n'"${IMAGE_NAME}:fingerprint-${INPUTS_FINGERPRINT}"
           if [[ "$PUBLISH_MODE" == "pr" ]]; then
             TAGS="${TAGS}"$'\n'"${PR_IMAGE_TAG}"
           fi
@@ -474,14 +490,20 @@ jobs:
               echo '```'
             elif [[ "$PUBLISH_MODE" == "pr" ]]; then
               echo ""
-              echo "_Integration resolves the PR-scoped tag above to this digest before running browser suites._"
+              echo "_Integration consumes this digest directly via the workflow_call output; the PR-scoped tag above is for provenance and manual debugging only._"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   offline-e2e:
     name: Required Offline Browser E2E
     needs: [build, publish]
-    if: needs.build.outputs.should_push == 'true' && needs.publish.result == 'success'
+    # On the standalone path (push to main, weekly schedule, manual dispatch)
+    # this job is the verification gate before the reviewed image-pin.json is
+    # refreshed. On the workflow_call path (integration.yml planner -> build)
+    # the calling Integration run's live-webclient-browser matrix is the
+    # verification, against the same digest we just published, so we skip
+    # offline-e2e here to avoid paying for the full browser regression twice.
+    if: needs.build.outputs.should_push == 'true' && needs.publish.result == 'success' && inputs.expected_fingerprint == ''
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -564,10 +564,226 @@ jobs:
   #   bulk browser logic suite does not depend on Windows-hosted Chromium
   #   process stability.
   # ───────────────────────────────────────────────────────────────────────────
+  # ───────────────────────────────────────────────────────────────────────────
+  # Browser CI image preparation DAG
+  #
+  # Replaces the previous "consumer polls GHCR for a tag the producer hasn't
+  # pushed yet" race with three explicit jobs:
+  #
+  #   prepare-browser-image-plan
+  #     Computes the current inputs_fingerprint over the canonical input set
+  #     (.github/docker/ijt-browser-ci/inputs-manifest.json). Compares against
+  #     image-pin.json.inputs_fingerprint, then against the GHCR
+  #     fingerprint-<hex> cache tag, then falls through to "build".
+  #
+  #   build-browser-image
+  #     Reusable workflow_call invocation of build-browser-ci-image.yml. Only
+  #     runs when prepare-browser-image-plan decides plan=build. Receives the
+  #     planner's fingerprint as an explicit, YAML-visible input contract.
+  #
+  #   resolve-browser-image
+  #     Single source of truth for the final digest-qualified image_ref.
+  #     Performs the SINGLE runtime trust check:
+  #       image.metadata.inputs_fingerprint == planner.current_fingerprint
+  #     build_sha is provenance only; same-fingerprint cache hits are accepted
+  #     even when their build_sha differs from $GITHUB_SHA.
+  #
+  # Only live-webclient-browser depends on this DAG. All other Integration jobs
+  # stay parallel; the planner/resolve overhead is ~20-30s on the pin/cache
+  # path, ~12 min on a true cold build (Browser CI inputs newly changed, no
+  # prior cache hit).
+  # ───────────────────────────────────────────────────────────────────────────
+  prepare-browser-image-plan:
+    name: "Browser CI image - resolve plan"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      plan: ${{ steps.decide.outputs.plan }}
+      image_name: ${{ steps.decide.outputs.image_name }}
+      candidate_digest: ${{ steps.decide.outputs.candidate_digest }}
+      current_fingerprint: ${{ steps.decide.outputs.current_fingerprint }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.14"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide image plan (pin -> cached -> build)
+        id: decide
+        env:
+          PIN_PATH: .github/docker/ijt-browser-ci/image-pin.json
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          IMG="$(jq -r .image "$PIN_PATH")"
+          PIN_DIGEST="$(jq -r .digest "$PIN_PATH")"
+          PIN_FP="$(jq -r '.inputs_fingerprint // empty' "$PIN_PATH")"
+          CUR_FP="$(python .github/scripts/compute_browser_image_fingerprint.py --format value)"
+
+          if ! [[ "$PIN_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error file=${PIN_PATH}::digest must match ^sha256:[0-9a-f]{64}\$, got: ${PIN_DIGEST}" >&2
+            exit 1
+          fi
+          if ! [[ "$CUR_FP" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::computed inputs_fingerprint is not 64 lowercase hex chars: ${CUR_FP}" >&2
+            exit 1
+          fi
+
+          echo "image_name=${IMG}" >> "$GITHUB_OUTPUT"
+          echo "current_fingerprint=${CUR_FP}" >> "$GITHUB_OUTPUT"
+
+          # Plan 1: reviewed pin is current. Use it. This is the common path
+          # for PRs that do NOT touch Browser CI image inputs.
+          if [[ "$PIN_FP" == "$CUR_FP" ]]; then
+            echo "plan=pin" >> "$GITHUB_OUTPUT"
+            echo "candidate_digest=${PIN_DIGEST}" >> "$GITHUB_OUTPUT"
+            echo "Plan: pin (image-pin.json matches current inputs_fingerprint)"
+            exit 0
+          fi
+
+          # Plan 2: GHCR has a fingerprint-keyed image from a prior build of
+          # the same inputs. Reuse it. Cache identity is fingerprint, not SHA;
+          # the digest emitted from this path may have been built from a
+          # different GITHUB_SHA, which is fine - the runtime trust check in
+          # resolve-browser-image verifies fingerprint equality.
+          cache_tag="${IMG}:fingerprint-${CUR_FP}"
+          if cached_digest="$(docker buildx imagetools inspect "$cache_tag" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"')" \
+             && [[ "$cached_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "plan=cached" >> "$GITHUB_OUTPUT"
+            echo "candidate_digest=${cached_digest}" >> "$GITHUB_OUTPUT"
+            echo "Plan: cached (resolved ${cache_tag} -> ${cached_digest})"
+            exit 0
+          fi
+
+          # Plan 3: cold build. Fork PRs cannot publish to GHCR (no
+          # packages: write on the calling job for forks), so fail fast here
+          # with a maintainer-facing diagnostic instead of starting a build
+          # job that would crash at the push step.
+          if [[ "$EVENT_NAME" == "pull_request" && -n "$PR_HEAD_REPO" && "$PR_HEAD_REPO" != "$GH_REPO" ]]; then
+            echo "::error file=${PIN_PATH}::Untrusted fork PR changed Browser CI image inputs and no fingerprint cache match was found." >&2
+            echo "::error::  current inputs_fingerprint: ${CUR_FP}" >&2
+            echo "::error::  action: a maintainer must re-run the PR from a same-repo branch, or refresh image-pin.json on main to pre-build the matching image." >&2
+            exit 1
+          fi
+
+          echo "plan=build" >> "$GITHUB_OUTPUT"
+          echo "Plan: build (no pin match, no cache hit; reusable workflow will publish)"
+
+  build-browser-image:
+    name: "Browser CI image - build (cold path)"
+    needs: prepare-browser-image-plan
+    if: needs.prepare-browser-image-plan.outputs.plan == 'build'
+    uses: ./.github/workflows/build-browser-ci-image.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    # No `secrets: inherit`: the reusable workflow only needs the auto-
+    # provided GITHUB_TOKEN for GHCR login (always available in called
+    # workflows without inheritance), and packages: write above is the
+    # capability that actually matters. Inheriting would broaden the secret
+    # surface unnecessarily — flagged by zizmor as secrets-inherit.
+    with:
+      expected_fingerprint: ${{ needs.prepare-browser-image-plan.outputs.current_fingerprint }}
+
+  resolve-browser-image:
+    name: "Browser CI image - resolve digest"
+    needs: [prepare-browser-image-plan, build-browser-image]
+    if: always() && needs.prepare-browser-image-plan.result == 'success' && (needs.build-browser-image.result == 'success' || needs.build-browser-image.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      image_ref: ${{ steps.pick.outputs.image_ref }}
+      plan: ${{ needs.prepare-browser-image-plan.outputs.plan }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pick final image_ref and validate metadata fingerprint
+        id: pick
+        env:
+          PLAN: ${{ needs.prepare-browser-image-plan.outputs.plan }}
+          IMG: ${{ needs.prepare-browser-image-plan.outputs.image_name }}
+          CANDIDATE_DIGEST: ${{ needs.prepare-browser-image-plan.outputs.candidate_digest }}
+          BUILD_DIGEST: ${{ needs.build-browser-image.outputs.digest }}
+          CURRENT_FINGERPRINT: ${{ needs.prepare-browser-image-plan.outputs.current_fingerprint }}
+        run: |
+          set -euo pipefail
+          case "$PLAN" in
+            pin|cached) DIGEST="$CANDIDATE_DIGEST" ;;
+            build)      DIGEST="$BUILD_DIGEST" ;;
+            *) echo "::error::invalid plan value: ${PLAN}" >&2; exit 1 ;;
+          esac
+          if ! [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::resolved digest is not sha256:<64hex>: ${DIGEST} (plan=${PLAN})" >&2
+            exit 1
+          fi
+          REF="${IMG}@${DIGEST}"
+
+          # SINGLE runtime trust check. inputs_fingerprint baked into the
+          # image at build time must equal the planner's fingerprint over the
+          # current source tree. Same-fingerprint cache hits are accepted
+          # regardless of which GITHUB_SHA produced the image; build_sha is
+          # provenance only and intentionally NOT checked here.
+          docker pull "$REF"
+          actual_fp="$(docker run --rm --network=none "$REF" \
+            python -c "import json; print(json.load(open('/opt/ijt-browser-ci/metadata.json')).get('inputs_fingerprint',''))")"
+          if [[ "$actual_fp" != "$CURRENT_FINGERPRINT" ]]; then
+            echo "::error::Image metadata inputs_fingerprint does not match the planner's fingerprint." >&2
+            echo "::error::  expected (planner): ${CURRENT_FINGERPRINT}" >&2
+            echo "::error::  actual   (image):   ${actual_fp}" >&2
+            echo "::error::  image:              ${REF}" >&2
+            echo "::error::  plan:               ${PLAN}" >&2
+            exit 1
+          fi
+          echo "image_ref=${REF}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## IJT Browser CI image resolved"
+            echo ""
+            echo "- Plan: \`${PLAN}\`"
+            echo "- Image ref: \`${REF}\`"
+            echo "- Inputs fingerprint: \`${CURRENT_FINGERPRINT}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Resolved IJT_BROWSER_CI_IMAGE=${REF} (plan=${PLAN})"
+
+  # ───────────────────────────────────────────────────────────────────────────
   live-webclient-browser:
     name: "Web Client Browser - ${{ matrix.label }}"
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    needs: resolve-browser-image
+    # Explicit status-check function is REQUIRED here. resolve-browser-image
+    # transitively depends on build-browser-image, which is intentionally
+    # skipped when the planner picks the reviewed pin or a fingerprint cache
+    # hit. GitHub's default success() evaluates the entire transitive needs
+    # graph, so without this if: the Browser matrix would be implicitly
+    # skipped on every PR that does not need a cold image build (the common
+    # case). The !cancelled() check ensures we still respect workflow
+    # cancellation. See invariant
+    # test_live_webclient_browser_job_overrides_default_success_check.
+    if: ${{ !cancelled() && needs.resolve-browser-image.result == 'success' }}
     permissions:
       contents: read
       packages: read
@@ -604,230 +820,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve IJT Browser CI image reference (digest-qualified)
-        id: image
+      - name: Pull IJT Browser CI image (digest from resolve-browser-image)
         env:
-          PIN_PATH: .github/docker/ijt-browser-ci/image-pin.json
-          EVENT_NAME: ${{ github.event_name }}
-          REF: ${{ github.ref }}
-          BEFORE_SHA: ${{ github.event.before || '' }}
-          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          IMG: ${{ needs.resolve-browser-image.outputs.image_ref }}
         run: |
           set -euo pipefail
-          IMG="$(jq -r .image "$PIN_PATH")"
-          DIG="$(jq -r .digest "$PIN_PATH")"
-          CURRENT_INPUTS_FINGERPRINT="$(python .github/scripts/compute_browser_image_fingerprint.py --format value)"
-          PIN_INPUTS_FINGERPRINT="$(jq -r '.inputs_fingerprint // empty' "$PIN_PATH")"
-
-          browser_image_inputs_changed() {
-            local base_sha="$1"
-            local head_sha="$2"
-            local changed_browser_image_input=false
-
-            git fetch --no-tags --depth=1 origin "$base_sha" "$head_sha"
-            changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
-            while IFS= read -r changed; do
-              [[ -n "$changed" ]] || continue
-              case "$changed" in
-                .dockerignore)
-                  changed_browser_image_input=true
-                  ;;
-                constraints.txt)
-                  changed_browser_image_input=true
-                  ;;
-                OPC_UA_Clients/Release2/IJT_Web_Client/package.json)
-                  changed_browser_image_input=true
-                  ;;
-                OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json)
-                  changed_browser_image_input=true
-                  ;;
-                OPC_UA_Clients/Release2/IJT_Web_Client/requirements.txt)
-                  changed_browser_image_input=true
-                  ;;
-                OPC_UA_Clients/Release2/IJT_Web_Client/requirements-dev.txt)
-                  changed_browser_image_input=true
-                  ;;
-                .github/docker/ijt-browser-ci/image-pin.json)
-                  ;;
-                .github/docker/ijt-browser-ci/README.md)
-                  ;;
-                .github/docker/ijt-browser-ci/*)
-                  changed_browser_image_input=true
-                  ;;
-                .github/scripts/update_browser_ci_image_pin.py)
-                  changed_browser_image_input=true
-                  ;;
-                .github/scripts/compute_browser_image_fingerprint.py)
-                  changed_browser_image_input=true
-                  ;;
-                .github/workflows/build-browser-ci-image.yml)
-                  changed_browser_image_input=true
-                  ;;
-              esac
-            done <<< "$changed_files"
-
-            [[ "$changed_browser_image_input" == "true" ]]
-          }
-
-          pull_tag_and_resolve_digest() {
-            local tag="$1"
-            local source="$2"
-            local expected_sha="$3"
-            local attempt=0
-            local max_attempts=30
-            local delay=20
-
-            echo "Waiting for ${source}: ${tag}"
-            until docker pull "$tag"; do
-              attempt=$((attempt + 1))
-              if [ "$attempt" -ge "$max_attempts" ]; then
-                echo "::error file=${PIN_PATH}::Timed out waiting for ${source}." >&2
-                echo "::error::  tag:      ${tag}" >&2
-                echo "::error::  workflow: .github/workflows/build-browser-ci-image.yml" >&2
-                echo "::error::  reason:   browser image input changed, but no matching PR/SHA image was published." >&2
-                exit 1
-              fi
-              echo "image tag not ready (${attempt}/${max_attempts}); retrying in ${delay}s..." >&2
-              sleep "$delay"
-            done
-
-            resolved_ref="$(
-              docker image inspect "$tag" --format '{{range .RepoDigests}}{{println .}}{{end}}' \
-                | grep -F "${IMG}@sha256:" \
-                | head -n 1 || true
-            )"
-            if [[ -z "$resolved_ref" ]]; then
-              echo "::error file=${PIN_PATH}::Pulled ${tag}, but Docker did not report a ${IMG}@sha256 digest." >&2
-              exit 1
-            fi
-            DIG="${resolved_ref##*@}"
-            echo "Resolved ${source} to ${IMG}@${DIG}"
-
-            actual_sha="$(
-              docker run --rm --network=none "${IMG}@${DIG}" \
-                python -c "import json; print(json.load(open('/opt/ijt-browser-ci/metadata.json')).get('build_sha',''))"
-            )"
-            if [[ "$actual_sha" != "$expected_sha" ]]; then
-              echo "::error file=${PIN_PATH}::Resolved ${source}, but image metadata does not match the expected source SHA." >&2
-              echo "::error::  expected: ${expected_sha}" >&2
-              echo "::error::  actual:   ${actual_sha}" >&2
-              echo "::error::  image:    ${IMG}@${DIG}" >&2
-              exit 1
-            fi
-
-            actual_fingerprint="$(
-              docker run --rm --network=none "${IMG}@${DIG}" \
-                python -c "import json; print(json.load(open('/opt/ijt-browser-ci/metadata.json')).get('inputs_fingerprint',''))"
-            )"
-            if [[ "$actual_fingerprint" != "$CURRENT_INPUTS_FINGERPRINT" ]]; then
-              echo "::error file=${PIN_PATH}::Resolved ${source}, but image metadata does not match the current Browser CI input fingerprint." >&2
-              echo "::error::  expected: ${CURRENT_INPUTS_FINGERPRINT}" >&2
-              echo "::error::  actual:   ${actual_fingerprint}" >&2
-              echo "::error::  image:    ${IMG}@${DIG}" >&2
-              echo "::error::  manifest: .github/docker/ijt-browser-ci/inputs-manifest.json" >&2
-              exit 1
-            fi
-          }
-
-          image_source="reviewed image-pin.json"
-          null_sha="0000000000000000000000000000000000000000"
-          if [[ "$EVENT_NAME" == "pull_request" && "$PR_HEAD_REPO" == "$GITHUB_REPOSITORY" ]]; then
-            if browser_image_inputs_changed "$PR_BASE_SHA" "$PR_HEAD_SHA"; then
-              short_sha="${GITHUB_SHA::7}"
-              pull_tag_and_resolve_digest "${IMG}:pr-${PR_NUMBER}-${short_sha}" "PR-scoped browser image" "$GITHUB_SHA"
-              image_source="PR-scoped browser image"
-            fi
-          elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" && -n "$BEFORE_SHA" && "$BEFORE_SHA" != "$null_sha" ]]; then
-            if browser_image_inputs_changed "$BEFORE_SHA" "$GITHUB_SHA"; then
-              short_sha="${GITHUB_SHA::7}"
-              pull_tag_and_resolve_digest "${IMG}:sha-${short_sha}" "main SHA browser image" "$GITHUB_SHA"
-              image_source="main SHA browser image"
-            fi
-          fi
-
-          if [[ "$image_source" == "reviewed image-pin.json" ]]; then
-            if ! [[ "$PIN_INPUTS_FINGERPRINT" =~ ^[0-9a-f]{64}$ ]]; then
-              echo "::error file=${PIN_PATH}::Reviewed Browser CI image pin is missing inputs_fingerprint." >&2
-              echo "::error::  current:  ${CURRENT_INPUTS_FINGERPRINT}" >&2
-              echo "::error::  manifest: .github/docker/ijt-browser-ci/inputs-manifest.json" >&2
-              echo "::error::  action:   rebuild/publish ijt-browser-ci and refresh image-pin.json through the reviewed pin flow." >&2
-              exit 1
-            fi
-            if [[ "$PIN_INPUTS_FINGERPRINT" != "$CURRENT_INPUTS_FINGERPRINT" ]]; then
-              echo "::error file=${PIN_PATH}::Browser CI image pin is stale for the current dependency inputs." >&2
-              echo "::error::  pinned:   ${PIN_INPUTS_FINGERPRINT}" >&2
-              echo "::error::  current:  ${CURRENT_INPUTS_FINGERPRINT}" >&2
-              echo "::error::  image:    ${IMG}@${DIG}" >&2
-              echo "::error::  manifest: .github/docker/ijt-browser-ci/inputs-manifest.json" >&2
-              echo "::error::  action:   rebuild/publish ijt-browser-ci and refresh image-pin.json through the reviewed pin flow." >&2
-              exit 1
-            fi
-            actual_fingerprint="$(
-              docker run --rm --network=none "${IMG}@${DIG}" \
-                python -c "import json; print(json.load(open('/opt/ijt-browser-ci/metadata.json')).get('inputs_fingerprint',''))"
-            )"
-            if [[ "$actual_fingerprint" != "$CURRENT_INPUTS_FINGERPRINT" ]]; then
-              echo "::error file=${PIN_PATH}::Reviewed Browser CI image metadata does not match the current input fingerprint." >&2
-              echo "::error::  pinned:   ${PIN_INPUTS_FINGERPRINT}" >&2
-              echo "::error::  current:  ${CURRENT_INPUTS_FINGERPRINT}" >&2
-              echo "::error::  actual:   ${actual_fingerprint}" >&2
-              echo "::error::  image:    ${IMG}@${DIG}" >&2
-              echo "::error::  manifest: .github/docker/ijt-browser-ci/inputs-manifest.json" >&2
-              echo "::error::  action:   rebuild/publish ijt-browser-ci and refresh image-pin.json through the reviewed pin flow." >&2
-              exit 1
-            fi
-          fi
-
-          if ! [[ "$DIG" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error file=$PIN_PATH::digest is not a valid sha256:<64hex> reference: $DIG" >&2
+          # No tag polling, no inferred identity. resolve-browser-image already
+          # pulled this digest on its runner and validated its metadata
+          # fingerprint; this pull is a per-runner cache warm-up so the
+          # subsequent docker run is local.
+          if ! [[ "$IMG" =~ @sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::IJT_BROWSER_CI_IMAGE is not digest-qualified: ${IMG}" >&2
             exit 1
           fi
-          REF="${IMG}@${DIG}"
-          if ! [[ "$REF" =~ @sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error file=$PIN_PATH::Resolved IJT_BROWSER_CI_IMAGE is not digest-qualified: $REF" >&2
-            exit 1
-          fi
-          echo "ijt_browser_ci_image=$REF" >> "$GITHUB_OUTPUT"
-          echo "image_source=${image_source}" >> "$GITHUB_OUTPUT"
-          echo "Resolved IJT_BROWSER_CI_IMAGE=$REF (${image_source}; inputs=${CURRENT_INPUTS_FINGERPRINT})"
-
-      - name: Pull IJT Browser CI image (3-attempt retry)
-        env:
-          IMG: ${{ steps.image.outputs.ijt_browser_ci_image }}
-          IMAGE_SOURCE: ${{ steps.image.outputs.image_source }}
-          PIN_PATH: .github/docker/ijt-browser-ci/image-pin.json
-        run: |
-          set -euo pipefail
-          # Retry 3x with backoff. GHCR is the SPOF this job depends on; if all
-          # three attempts fail the diagnostic must name the digest, the
-          # registry, and the image-build workflow so the operator can decide
-          # whether to re-run the publish workflow or wait out a GHCR incident.
-          attempt=0
-          max_attempts=3
-          delay=5
-          until docker pull "$IMG"; do
-            attempt=$((attempt + 1))
-            if [ "$attempt" -ge "$max_attempts" ]; then
-              echo "::error file=${PIN_PATH}::Failed to pull IJT Browser CI image after ${max_attempts} attempts." >&2
-              echo "::error::  image:    ${IMG}" >&2
-              echo "::error::  source:   ${IMAGE_SOURCE}" >&2
-              echo "::error::  registry: ghcr.io (GHCR)" >&2
-              echo "::error::  pin file: ${PIN_PATH}" >&2
-              echo "::error::  republish: re-run .github/workflows/build-browser-ci-image.yml to regenerate the matching image, then re-run Integration." >&2
-              exit 1
-            fi
-            echo "docker pull attempt ${attempt}/${max_attempts} failed; retrying in ${delay}s..." >&2
-            sleep "$delay"
-            delay=$((delay * 2))
-          done
+          docker pull "$IMG"
           docker image inspect "$IMG" --format 'id={{.Id}} created={{.Created}}'
 
       - name: Run Web Client browser e2e suite (offline, --network=none)
         env:
-          IMG: ${{ steps.image.outputs.ijt_browser_ci_image }}
+          IMG: ${{ needs.resolve-browser-image.outputs.image_ref }}
           SUITE: ${{ matrix.suite }}
           SHARD: ${{ matrix.feature_shard || '' }}
         run: |

--- a/tests/test_ci_synchronization_invariants.py
+++ b/tests/test_ci_synchronization_invariants.py
@@ -1,0 +1,312 @@
+"""CI synchronization invariants for the Browser CI image path.
+
+These tests guard the architectural contract that fixed the producer/consumer
+race documented in run 26257538245 (PR #394). The principle:
+
+    No external waits. No inferred identity. No timeout-as-sync.
+    Producer and consumer must share a dependency edge with a passed-forward
+    output. Cache identity is `inputs_fingerprint`. Runtime identity is
+    `digest`. `GITHUB_SHA` is provenance, never validation.
+
+If any of these invariants regress, the fix is structural, not a snapshot
+update. Read the comments before relaxing an assertion.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_INTEGRATION_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "integration.yml"
+_IMAGE_BUILD_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "build-browser-ci-image.yml"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1: no workflow step couples `docker pull` to a long polling loop.
+# ---------------------------------------------------------------------------
+# The historical failure was a `docker pull "$tag"` inside a `for attempt in
+# $(seq 1 30); do ... sleep 20; done` budget (10 minutes) used as the
+# synchronization mechanism with a separate producer workflow. That pattern
+# is forbidden anywhere in the repo's workflows; image identity must arrive
+# via `needs:` + a job output, not by polling GHCR for an external producer
+# to land a tag.
+
+_DOCKER_PULL_RE = re.compile(r"\bdocker\s+pull\b")
+_LOOP_RE = re.compile(r"\b(for|while|until)\b")
+_SEQ_RE = re.compile(r"\bseq\s+1\s+(\d+)\b")
+_MAX_ATTEMPTS_RE = re.compile(r"max_attempts\s*=\s*(\d+)")
+_SLEEP_RE = re.compile(r"\bsleep\s+(\d+)\b")
+
+
+def _walk_workflow_steps(workflow: dict):
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        for step in job.get("steps") or []:
+            yield job_name, step
+
+
+@pytest.mark.parametrize(
+    "workflow_path",
+    [_INTEGRATION_WORKFLOW, _IMAGE_BUILD_WORKFLOW],
+    ids=["integration", "build-browser-ci-image"],
+)
+def test_no_docker_pull_polling_loop_with_long_budget(workflow_path: Path) -> None:
+    workflow = _load(workflow_path)
+    for job_name, step in _walk_workflow_steps(workflow):
+        run = step.get("run") or ""
+        if not run or not _DOCKER_PULL_RE.search(run):
+            continue
+        if not _LOOP_RE.search(run):
+            continue
+        # Loop + docker pull -> compute total wait budget.
+        attempts = 0
+        for m in _SEQ_RE.finditer(run):
+            attempts = max(attempts, int(m.group(1)))
+        for m in _MAX_ATTEMPTS_RE.finditer(run):
+            attempts = max(attempts, int(m.group(1)))
+        delays = [int(m.group(1)) for m in _SLEEP_RE.finditer(run)]
+        max_delay = max(delays) if delays else 0
+        budget = attempts * max_delay
+        # 180s is the warm-Docker-pull ceiling shared with compose_up_total
+        # in tests/conftest.py; anything beyond that is polling-as-sync.
+        assert budget <= 180, (
+            f"Step '{step.get('name')}' in job '{job_name}' couples docker pull "
+            f"to a {budget}s polling loop ({attempts} attempts x {max_delay}s). "
+            "That is the broken contract that caused run 26257538245. "
+            "Image identity must flow through `needs:` + a job output, not "
+            "by polling GHCR for an external producer to land a tag."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2: live-webclient-browser reaches resolve-browser-image via needs:
+# ---------------------------------------------------------------------------
+# The Browser matrix must depend on the resolver job. If someone reintroduces
+# a parallel matrix that resolves identity inside its own steps, the race
+# returns. This is the structural fix.
+
+
+def test_live_webclient_browser_needs_resolve_browser_image() -> None:
+    workflow = _load(_INTEGRATION_WORKFLOW)
+    job = workflow["jobs"]["live-webclient-browser"]
+    needs = job.get("needs")
+    if isinstance(needs, str):
+        needs = [needs]
+    assert needs and "resolve-browser-image" in needs, (
+        "live-webclient-browser must declare `needs: resolve-browser-image` "
+        "so image identity is a passed-forward output, not a tag poll."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3: IJT_BROWSER_CI_IMAGE comes from a job-output expression.
+# ---------------------------------------------------------------------------
+# Steps that run the browser image must source the image reference from
+# `${{ needs.resolve-browser-image.outputs.image_ref }}`, never from a
+# step-output written by an in-job `docker pull`. The historical resolver
+# wrote `image_ref` into a step output AFTER polling for a tag — that is
+# precisely the inferred-identity pattern this commit eliminates.
+
+_JOB_OUTPUT_REF = re.compile(r"\$\{\{\s*needs\.resolve-browser-image\.outputs\.image_ref\s*\}\}")
+_STEP_OUTPUT_REF = re.compile(r"\$\{\{\s*steps\.[A-Za-z0-9_]+\.outputs\.image_ref\s*\}\}")
+
+
+def test_browser_matrix_image_ref_comes_from_job_output_not_step_output() -> None:
+    workflow = _load(_INTEGRATION_WORKFLOW)
+    job = workflow["jobs"]["live-webclient-browser"]
+    saw_job_output_ref = False
+    for step in job.get("steps") or []:
+        # env block
+        env_blob = "\n".join(f"{k}: {v}" for k, v in (step.get("env") or {}).items())
+        run_blob = step.get("run") or ""
+        for blob in (env_blob, run_blob):
+            assert not _STEP_OUTPUT_REF.search(blob), (
+                f"Step '{step.get('name')}' references a step-output `image_ref`. "
+                "Image identity must come from needs.resolve-browser-image.outputs.image_ref, "
+                "not from an in-job docker-pull side effect."
+            )
+            if _JOB_OUTPUT_REF.search(blob):
+                saw_job_output_ref = True
+    assert saw_job_output_ref, (
+        "live-webclient-browser must consume "
+        "needs.resolve-browser-image.outputs.image_ref in at least one step."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4: cache identity is fingerprint; runtime identity is digest.
+# ---------------------------------------------------------------------------
+# The resolver's metadata-check step must compare image.inputs_fingerprint
+# against the planner's CURRENT_FINGERPRINT. It must NOT require build_sha
+# to equal GITHUB_SHA: a fingerprint-cache hit is by construction allowed to
+# have been built from an earlier SHA with identical inputs. Enforcing SHA
+# equality would defeat the cache.
+
+
+def test_resolve_step_uses_fingerprint_equality_not_build_sha() -> None:
+    workflow = _load(_INTEGRATION_WORKFLOW)
+    resolve_job = workflow["jobs"]["resolve-browser-image"]
+    pick_step = next(
+        step
+        for step in resolve_job["steps"]
+        if step.get("name") == "Pick final image_ref and validate metadata fingerprint"
+    )
+    body = pick_step["run"]
+    env = pick_step.get("env") or {}
+    assert "CURRENT_FINGERPRINT" in env, (
+        "Resolver pick step must receive the planner's fingerprint via env."
+    )
+    assert "inputs_fingerprint" in body
+    assert "actual_fp" in body and "CURRENT_FINGERPRINT" in body, (
+        "Resolver must compare image metadata inputs_fingerprint against "
+        "CURRENT_FINGERPRINT — that is the single runtime trust check."
+    )
+    # Strip comment lines so the negative assertion can't be tripped by a
+    # comment that mentions `build_sha` as provenance-only context.
+    code_lines = [line for line in body.splitlines() if not line.lstrip().startswith("#")]
+    code_only = "\n".join(code_lines)
+    assert "build_sha" not in code_only, (
+        "Resolver code must NOT reference image build_sha. A "
+        "fingerprint-cache hit can legitimately carry a different build_sha; "
+        "fingerprint equality is the trust check."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5: producer exposes workflow_call with the planner's contract.
+# ---------------------------------------------------------------------------
+# The producer's PR-time entry point is workflow_call from integration.yml.
+# It must accept an `expected_fingerprint` input and emit `digest`,
+# `source_sha`, `inputs_fingerprint` outputs. Drift between this signature
+# and the consumer's call site is what dual-tagging or tag polling tried to
+# paper over before.
+
+
+def test_producer_exposes_workflow_call_with_fingerprint_contract() -> None:
+    workflow = _load(_IMAGE_BUILD_WORKFLOW)
+    triggers = workflow.get("on", workflow.get(True, {}))
+    assert "workflow_call" in triggers, (
+        "build-browser-ci-image.yml must expose workflow_call so integration.yml "
+        "can invoke it as part of one execution graph."
+    )
+    wc = triggers["workflow_call"]
+    expected = wc.get("inputs", {}).get("expected_fingerprint")
+    assert expected, "workflow_call must declare an expected_fingerprint input."
+    assert expected.get("required") is True
+    assert expected.get("type") == "string"
+    outputs = wc.get("outputs") or {}
+    for name in ("digest", "source_sha", "inputs_fingerprint"):
+        assert name in outputs, f"workflow_call must emit a `{name}` output for consumer wiring."
+
+
+# ---------------------------------------------------------------------------
+# Invariant 6: producer publishes a fingerprint-keyed cache tag.
+# ---------------------------------------------------------------------------
+# Repeated Renovate-style PRs with identical Browser CI image inputs must be
+# able to short-circuit at the planner via a GHCR tag lookup. That requires
+# the producer to publish `${IMAGE_NAME}:fingerprint-<hex>` on every push.
+
+
+def test_producer_publishes_fingerprint_cache_tag() -> None:
+    workflow = _load(_IMAGE_BUILD_WORKFLOW)
+    publish_job = workflow["jobs"]["publish"]
+    tags_step = next(
+        step for step in publish_job["steps"] if step.get("name") == "Compute publish tags"
+    )
+    assert "${IMAGE_NAME}:fingerprint-${INPUTS_FINGERPRINT}" in tags_step["run"], (
+        "Publish must include a fingerprint-keyed cache tag so the planner "
+        "can short-circuit cold builds for repeated same-input PRs."
+    )
+
+
+def test_planner_decision_table_emits_three_plans() -> None:
+    workflow = _load(_INTEGRATION_WORKFLOW)
+    planner = workflow["jobs"]["prepare-browser-image-plan"]
+    decide_step = next(
+        step
+        for step in planner["steps"]
+        if step.get("name") == "Decide image plan (pin -> cached -> build)"
+    )
+    body = decide_step["run"]
+    for plan in ("plan=pin", "plan=cached", "plan=build"):
+        assert plan in body, f"Planner must be able to emit `{plan}`."
+    # Untrusted fork PRs with no cache hit must fail fast with a maintainer
+    # diagnostic rather than starting a build job that lacks packages: write.
+    assert "Untrusted fork PR" in body, (
+        "Planner must fail fast for fork PRs with no fingerprint cache hit."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 7: planner discriminates pin / cached / build deterministically
+# (handled above by test_planner_decision_table_emits_three_plans).
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Invariant 8: reusable workflow call must NOT use `secrets: inherit`.
+# ---------------------------------------------------------------------------
+# The reusable build-browser-ci-image workflow only needs the auto-provided
+# GITHUB_TOKEN for GHCR login (available without inheritance) plus the
+# packages: write capability granted via job permissions. `secrets: inherit`
+# would broaden the secret surface to every caller secret unnecessarily —
+# zizmor flags it as `secrets-inherit` and Codex blocked Commit A on this
+# during read-only review.
+
+
+def test_build_browser_image_call_does_not_inherit_all_secrets() -> None:
+    workflow = _load(_INTEGRATION_WORKFLOW)
+    build_call = workflow["jobs"]["build-browser-image"]
+    assert "secrets" not in build_call or build_call.get("secrets") != "inherit", (
+        "build-browser-image must NOT use `secrets: inherit`. The reusable "
+        "workflow only needs GITHUB_TOKEN (auto-provided) and packages: write "
+        "(granted via job permissions). Inheriting all caller secrets violates "
+        "least-privilege and is flagged by zizmor as secrets-inherit."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 9: live-webclient-browser overrides the default success() check.
+# ---------------------------------------------------------------------------
+# resolve-browser-image uses `if: always() && ...` so it runs even when
+# build-browser-image is skipped (the common pin/cache path). GitHub's
+# default `if: success()` evaluates the entire transitive `needs` graph,
+# so a downstream job without its own `if:` would be implicitly skipped on
+# every PR that does not require a cold image build. The Browser matrix
+# must therefore declare a status-check function (`!cancelled()` or
+# `always()`) AND require resolve-browser-image to have succeeded.
+
+_STATUS_CHECK_RE = re.compile(r"!\s*cancelled\s*\(\s*\)|\balways\s*\(\s*\)")
+_RESOLVE_SUCCESS_RE = re.compile(r"needs\.resolve-browser-image\.result\s*==\s*['\"]success['\"]")
+
+
+def test_live_webclient_browser_job_overrides_default_success_check() -> None:
+    workflow = _load(_INTEGRATION_WORKFLOW)
+    job = workflow["jobs"]["live-webclient-browser"]
+    if_expr = job.get("if")
+    assert if_expr, (
+        "live-webclient-browser MUST declare an explicit `if:` because its "
+        "upstream resolve-browser-image uses `if: always()`. Without an "
+        "explicit status-check function, GitHub's default success() will "
+        "skip the Browser matrix whenever build-browser-image is skipped "
+        "(the common pin/cache path)."
+    )
+    if_text = str(if_expr)
+    assert _STATUS_CHECK_RE.search(if_text), (
+        "live-webclient-browser.if must contain a status-check function "
+        "such as !cancelled() or always() to override the default success() "
+        f"evaluation of the transitive needs graph. Got: {if_text!r}"
+    )
+    assert _RESOLVE_SUCCESS_RE.search(if_text), (
+        "live-webclient-browser.if must require "
+        "needs.resolve-browser-image.result == 'success' so the Browser "
+        "matrix never runs against an unresolved or failed image_ref. "
+        f"Got: {if_text!r}"
+    )

--- a/tests/test_image_pin.py
+++ b/tests/test_image_pin.py
@@ -152,16 +152,25 @@ def test_build_workflow_path_filters_cover_browser_ci_inputs_manifest() -> None:
     workflow = yaml.safe_load(_IMAGE_BUILD_WORKFLOW.read_text(encoding="utf-8"))
     triggers = workflow.get("on", workflow.get(True, {}))
     manifest_paths = _load_inputs_manifest()["paths"]
-    for event_name in ("push", "pull_request"):
-        paths = triggers[event_name]["paths"]
-        missing = [path for path in manifest_paths if not _workflow_path_includes(path, paths)]
-        assert not missing, (
-            f"build-browser-ci-image.yml {event_name} paths must cover every "
-            "Browser CI image input manifest path: " + ", ".join(missing)
-        )
+    # Producer is triggered directly on push to main / schedule / workflow_dispatch /
+    # workflow_call. There is intentionally no pull_request trigger: PR-time
+    # builds go through integration.yml's prepare-browser-image-plan -> build-
+    # browser-image (workflow_call) DAG, so producer and consumer share a
+    # single execution graph instead of synchronising through GHCR tag polling.
+    assert "pull_request" not in triggers, (
+        "build-browser-ci-image.yml must not declare a pull_request trigger; "
+        "PR builds go through integration.yml workflow_call so producer and "
+        "consumer are one execution graph."
+    )
+    paths = triggers["push"]["paths"]
+    missing = [path for path in manifest_paths if not _workflow_path_includes(path, paths)]
+    assert not missing, (
+        "build-browser-ci-image.yml push paths must cover every "
+        "Browser CI image input manifest path: " + ", ".join(missing)
+    )
 
-        assert not _workflow_path_includes(".github/docker/ijt-browser-ci/image-pin.json", paths)
-        assert not _workflow_path_includes(".github/docker/ijt-browser-ci/README.md", paths)
+    assert not _workflow_path_includes(".github/docker/ijt-browser-ci/image-pin.json", paths)
+    assert not _workflow_path_includes(".github/docker/ijt-browser-ci/README.md", paths)
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +248,7 @@ def test_ijt_browser_ci_image_env_var_is_workflow_or_image_config_only() -> None
     allowed_exact = {
         Path(".github/scripts/update_browser_ci_image_pin.py"),
         Path("tests/test_image_pin.py"),
+        Path("tests/test_ci_synchronization_invariants.py"),
     }
     offenders: list[str] = []
 
@@ -466,19 +476,38 @@ def test_build_browser_ci_image_workflow_keeps_pin_updates_manual_without_loop()
     workflow_text = _IMAGE_BUILD_WORKFLOW.read_text(encoding="utf-8")
     workflow = yaml.safe_load(workflow_text)
     triggers = workflow.get("on", workflow.get(True, {}))
-    for event_name in ("push", "pull_request"):
-        paths = triggers[event_name]["paths"]
-        docker_glob_index = paths.index(".github/docker/ijt-browser-ci/**")
-        pin_exclude_index = paths.index("!.github/docker/ijt-browser-ci/image-pin.json")
-        readme_exclude_index = paths.index("!.github/docker/ijt-browser-ci/README.md")
-        assert docker_glob_index < pin_exclude_index, (
-            "image-pin.json must be excluded after the docker directory include; "
-            "otherwise the automation branch can publish a fresh image and loop."
-        )
-        assert docker_glob_index < readme_exclude_index, (
-            "README.md must be excluded after the docker directory include; "
-            "documentation-only edits must not rebuild and republish the browser image."
-        )
+    paths = triggers["push"]["paths"]
+    docker_glob_index = paths.index(".github/docker/ijt-browser-ci/**")
+    pin_exclude_index = paths.index("!.github/docker/ijt-browser-ci/image-pin.json")
+    readme_exclude_index = paths.index("!.github/docker/ijt-browser-ci/README.md")
+    assert docker_glob_index < pin_exclude_index, (
+        "image-pin.json must be excluded after the docker directory include; "
+        "otherwise the automation branch can publish a fresh image and loop."
+    )
+    assert docker_glob_index < readme_exclude_index, (
+        "README.md must be excluded after the docker directory include; "
+        "documentation-only edits must not rebuild and republish the browser image."
+    )
+
+    # workflow_call is the producer's PR-time entry point, invoked from
+    # integration.yml's build-browser-image job. The expected_fingerprint
+    # input is the YAML-visible cache identity contract: planner computes a
+    # fingerprint, build job asserts equality, and the published image
+    # metadata carries the same fingerprint so the consumer can do a single
+    # runtime trust check (fingerprint equality) instead of polling.
+    assert "workflow_call" in triggers, (
+        "build-browser-ci-image.yml must expose workflow_call so integration.yml "
+        "can invoke it as part of one execution graph."
+    )
+    wc = triggers["workflow_call"]
+    assert wc["inputs"]["expected_fingerprint"]["required"] is True
+    assert wc["inputs"]["expected_fingerprint"]["type"] == "string"
+    wc_outputs = wc["outputs"]
+    assert wc_outputs["digest"]["value"] == "${{ jobs.publish.outputs.digest }}"
+    assert wc_outputs["source_sha"]["value"] == "${{ jobs.build.outputs.source_sha }}"
+    assert (
+        wc_outputs["inputs_fingerprint"]["value"] == "${{ jobs.build.outputs.inputs_fingerprint }}"
+    )
 
     assert workflow["permissions"] == {"contents": "read"}
     jobs = workflow["jobs"]
@@ -498,6 +527,19 @@ def test_build_browser_ci_image_workflow_keeps_pin_updates_manual_without_loop()
         "workflow checkout SHA."
     )
 
+    # Fingerprint guard: when invoked via workflow_call the build step must
+    # assert the planner's expected_fingerprint matches what this checkout
+    # computes. Drift between planner and build is a hard failure.
+    fingerprint_guard = next(
+        step
+        for step in build_job["steps"]
+        if step.get("name") == "Assert caller's expected fingerprint matches this checkout"
+    )
+    assert "inputs.expected_fingerprint" in (fingerprint_guard.get("if") or "")
+    fp_guard_body = fingerprint_guard["run"]
+    assert "EXPECTED_FINGERPRINT" in fp_guard_body
+    assert "COMPUTED_FINGERPRINT" in fp_guard_body
+
     decide_step = next(
         step
         for step in build_job["steps"]
@@ -505,23 +547,21 @@ def test_build_browser_ci_image_workflow_keeps_pin_updates_manual_without_loop()
     )
     decide_body = decide_step["run"]
     assert "PR_HEAD_REPO" in decide_step["env"]
-    assert "PR_HEAD_SHA" in decide_step["env"]
+    assert "EXPECTED_FINGERPRINT" in decide_step["env"]
     assert 'SOURCE_SHA="$GITHUB_SHA"' in decide_body
     assert "trusted_dependency_bot" not in decide_body
-    assert "browser_image_inputs_changed=false" in decide_body
-    assert "OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json" in decide_body
-    assert ".github/docker/ijt-browser-ci/*" in decide_body
-    assert ".github/scripts/compute_browser_image_fingerprint.py" in decide_body
-    assert ".github/docker/ijt-browser-ci/image-pin.json)" in decide_body
-    assert ".github/docker/ijt-browser-ci/README.md)" in decide_body
-    assert decide_body.index(".github/docker/ijt-browser-ci/image-pin.json)") < decide_body.index(
-        ".github/docker/ijt-browser-ci/*)"
-    )
-    assert decide_body.index(".github/docker/ijt-browser-ci/README.md)") < decide_body.index(
-        ".github/docker/ijt-browser-ci/*)"
-    )
     assert 'PUBLISH_MODE="pr"' in decide_body
     assert 'PR_IMAGE_TAG="${IMAGE_NAME}:pr-${PR_NUMBER}-${SHORT_SHA}"' in decide_body
+    # The producer no longer inlines a `browser_image_inputs_changed` shell
+    # function; integration.yml's planner owns "did inputs change?" via the
+    # compute_browser_image_fingerprint.py contract, and only invokes
+    # workflow_call when a build is actually needed.
+    assert "browser_image_inputs_changed" not in decide_body, (
+        "Producer must not re-derive whether inputs changed; the planner in "
+        "integration.yml is the single source of truth via inputs-manifest.json + "
+        "compute_browser_image_fingerprint.py."
+    )
+
     build_body = "\n".join(str(step.get("run", "")) for step in build_job["steps"])
     assert "compute_browser_image_fingerprint.py --format github-output" in build_body
     assert "inputs_fingerprint" in build_body
@@ -548,8 +588,10 @@ def test_build_browser_ci_image_workflow_keeps_pin_updates_manual_without_loop()
     assert "${{ steps.fingerprint.outputs.inputs_fingerprint }}" not in summary_step["run"]
     assert "web-client-e2e-regression" not in build_body, (
         "The image publish gate must validate image integrity only. Full browser "
-        "behavior belongs in the post-publish offline-e2e job so product "
-        "regressions do not prevent publishing the PR/SHA image Integration needs."
+        "behavior belongs in the post-publish offline-e2e job (standalone path) "
+        "or in the calling Integration run's live-webclient-browser matrix "
+        "(workflow_call path), so product regressions do not prevent publishing "
+        "the digest those consumers need."
     )
     assert "npm ci --legacy-peer-deps --offline --no-audit --no-fund" in build_body
     assert "--find-links /opt/ijt-browser-ci/pip-wheelhouse" in build_body
@@ -577,9 +619,17 @@ def test_build_browser_ci_image_workflow_keeps_pin_updates_manual_without_loop()
     assert "pull-requests: write" not in workflow_text
     offline_job = jobs["offline-e2e"]
     assert offline_job["needs"] == ["build", "publish"]
-    assert (
-        offline_job["if"]
-        == "needs.build.outputs.should_push == 'true' && needs.publish.result == 'success'"
+    # The offline-e2e gate runs on the standalone path only (push to main,
+    # schedule, workflow_dispatch). When invoked via workflow_call from
+    # integration.yml, the calling run's live-webclient-browser matrix is
+    # the verification against the same digest, so paying for the full
+    # browser regression twice would be redundant.
+    offline_if = offline_job["if"]
+    assert "needs.build.outputs.should_push == 'true'" in offline_if
+    assert "needs.publish.result == 'success'" in offline_if
+    assert "inputs.expected_fingerprint == ''" in offline_if, (
+        "offline-e2e must be skipped on the workflow_call path; integration.yml's "
+        "live-webclient-browser matrix is the verification for that path."
     )
     assert offline_job["permissions"] == {"contents": "read", "packages": "read"}
     assert offline_job["timeout-minutes"] == 45
@@ -611,7 +661,15 @@ def test_build_browser_ci_image_workflow_keeps_pin_updates_manual_without_loop()
     )
     assert "PUBLISH_MODE" in publish_tags_step["env"]
     assert "PR_IMAGE_TAG" in publish_tags_step["env"]
+    assert "INPUTS_FINGERPRINT" in publish_tags_step["env"]
     assert "${PR_IMAGE_TAG}" in publish_tags_step["run"]
+    # The fingerprint-<hex> tag is the cache identity used by integration.yml's
+    # planner. Repeated Renovate PRs with identical Browser CI image inputs
+    # resolve this tag to an existing digest and skip the build entirely.
+    assert "${IMAGE_NAME}:fingerprint-${INPUTS_FINGERPRINT}" in publish_tags_step["run"], (
+        "Publish must include a fingerprint-<hex> tag so future same-input "
+        "builds can short-circuit at the planner."
+    )
     publish_verify_step = next(
         step
         for step in publish_job["steps"]
@@ -653,7 +711,10 @@ def test_browser_ci_phase0_runtime_probe_uses_writable_home_paths() -> None:
 
 
 def test_integration_workflow_runs_for_image_pin_updates() -> None:
-    """Pin PRs and merges must exercise the browser Integration workflow."""
+    """Pin PRs and merges must exercise the browser Integration workflow, and the
+    planner (prepare-browser-image-plan) must read image-pin.json + compute the
+    current fingerprint to decide pin / cached / build.
+    """
     import yaml
 
     workflow = yaml.safe_load(_INTEGRATION_WORKFLOW.read_text(encoding="utf-8"))
@@ -668,30 +729,68 @@ def test_integration_workflow_runs_for_image_pin_updates() -> None:
         "main-branch run for the reviewed digest."
     )
 
-    resolve_step = next(
+    # The legacy in-job resolver step in live-webclient-browser is gone.
+    # Image identity now flows through three explicit jobs: planner (reads
+    # pin + computes fingerprint), conditional reusable-workflow build, and
+    # resolver (picks pin / cached / build digest and runs the single
+    # fingerprint-equality runtime trust check).
+    planner_job = workflow["jobs"]["prepare-browser-image-plan"]
+    decide_step = next(
         step
-        for step in workflow["jobs"]["live-webclient-browser"]["steps"]
-        if step.get("name") == "Resolve IJT Browser CI image reference (digest-qualified)"
+        for step in planner_job["steps"]
+        if step.get("name") == "Decide image plan (pin -> cached -> build)"
     )
-    resolve_body = resolve_step["run"]
-    assert ".github/docker/ijt-browser-ci/image-pin.json)" in resolve_body
-    assert ".github/docker/ijt-browser-ci/README.md)" in resolve_body
-    assert resolve_body.index(".github/docker/ijt-browser-ci/image-pin.json)") < resolve_body.index(
-        ".github/docker/ijt-browser-ci/*)"
+    assert (
+        decide_step.get("env", {}).get("PIN_PATH") == ".github/docker/ijt-browser-ci/image-pin.json"
     )
-    assert resolve_body.index(".github/docker/ijt-browser-ci/README.md)") < resolve_body.index(
-        ".github/docker/ijt-browser-ci/*)"
+    decide_body = decide_step["run"]
+    assert "compute_browser_image_fingerprint.py --format value" in decide_body
+    assert "PIN_FP" in decide_body and "CUR_FP" in decide_body
+    assert "plan=pin" in decide_body
+    assert "plan=cached" in decide_body
+    assert "plan=build" in decide_body
+    assert "fingerprint-${CUR_FP}" in decide_body, (
+        "Planner must look up the fingerprint-<hex> GHCR tag as the cache "
+        "identity before falling through to a cold build."
     )
-    assert "compute_browser_image_fingerprint.py --format value" in resolve_body
-    assert "CURRENT_INPUTS_FINGERPRINT" in resolve_body
-    assert "PIN_INPUTS_FINGERPRINT" in resolve_body
-    assert ".github/scripts/compute_browser_image_fingerprint.py" in resolve_body
-    assert "Browser CI image pin is stale for the current dependency inputs" in resolve_body
-    assert "Reviewed Browser CI image metadata does not match the current input fingerprint" in (
-        resolve_body
+
+    # live-webclient-browser must consume the planner+resolver chain via
+    # needs:, not by re-resolving the image inside its own steps.
+    browser_job = workflow["jobs"]["live-webclient-browser"]
+    needs = browser_job.get("needs")
+    if isinstance(needs, str):
+        needs = [needs]
+    assert "resolve-browser-image" in (needs or []), (
+        "live-webclient-browser must declare `needs: resolve-browser-image` so "
+        "image identity is a passed-forward job output, not a tag poll."
     )
-    assert "inputs_fingerprint" in resolve_body
-    assert "actual_fingerprint" in resolve_body
+
+    # Resolver pick step performs the SINGLE runtime trust check:
+    # image.metadata.inputs_fingerprint == planner.current_fingerprint.
+    # build_sha is provenance only; cached cross-PR images with identical
+    # fingerprints but different build SHAs are accepted.
+    resolve_job = workflow["jobs"]["resolve-browser-image"]
+    pick_step = next(
+        step
+        for step in resolve_job["steps"]
+        if step.get("name") == "Pick final image_ref and validate metadata fingerprint"
+    )
+    pick_body = pick_step["run"]
+    assert "CURRENT_FINGERPRINT" in pick_step["env"]
+    assert "/opt/ijt-browser-ci/metadata.json" in pick_body
+    assert "inputs_fingerprint" in pick_body
+    assert "actual_fp" in pick_body
+    # No build_sha equality check on the consumer side. Cache hits may have
+    # been built from a different GITHUB_SHA with identical inputs. Strip
+    # comment lines so a documenting comment can't trip the negative.
+    pick_code_only = "\n".join(
+        line for line in pick_body.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "build_sha" not in pick_code_only, (
+        "Resolver code must NOT compare image build_sha to current GITHUB_SHA. "
+        "build_sha is provenance only; fingerprint equality is the runtime "
+        "trust check for cache reuse to work."
+    )
 
 
 def test_browser_ci_dockerfile_derives_asyncua_runtime_constraint_from_wheel() -> None:

--- a/tests/test_root_runner.py
+++ b/tests/test_root_runner.py
@@ -1758,19 +1758,42 @@ def test_integration_web_client_e2e_jobs_run_on_stock_ubuntu_runner() -> None:
             "to authenticate against GHCR for the ijt-browser-ci pull."
         )
 
+        # Image identity is provided by the resolve-browser-image job via
+        # `needs:` + an explicit output expression. The legacy in-job resolver
+        # step (which polled GHCR tags with a 10-minute blind budget and
+        # raced the producer workflow) is intentionally gone.
+        needs = job.get("needs")
+        if isinstance(needs, str):
+            needs = [needs]
+        assert "resolve-browser-image" in (needs or []), (
+            "live-webclient-browser must declare `needs: resolve-browser-image` "
+            "so image identity flows through one execution DAG, not through "
+            "cross-workflow tag polling."
+        )
+
         steps = job["steps"]
         step_names = [step.get("name") or step.get("uses", "") for step in steps]
-        resolve_index = step_names.index(
-            "Resolve IJT Browser CI image reference (digest-qualified)"
+        assert "Resolve IJT Browser CI image reference (digest-qualified)" not in step_names, (
+            "The in-job resolver step was deleted in the Browser CI "
+            "synchronization commit. Image identity now comes from "
+            "needs.resolve-browser-image.outputs.image_ref."
         )
+        assert "Pull IJT Browser CI image (3-attempt retry)" not in step_names, (
+            "The 3-attempt retry pull step is deleted; resolve-browser-image "
+            "already pulled and validated the digest on its runner, so the "
+            "matrix job only needs a per-runner cache warm-up pull."
+        )
+
         login_index = next(
             index
             for index, step in enumerate(steps)
             if step.get("uses", "").startswith("docker/login-action@")
         )
-        assert login_index < resolve_index, (
-            "Resolve step may pull the reviewed GHCR image digest; docker login "
-            "must happen before resolving the browser image reference."
+        pull_index = step_names.index(
+            "Pull IJT Browser CI image (digest from resolve-browser-image)"
+        )
+        assert login_index < pull_index, (
+            "docker login must happen before the per-runner cache warm-up pull."
         )
 
         assert not any(
@@ -1784,68 +1807,38 @@ def test_integration_web_client_e2e_jobs_run_on_stock_ubuntu_runner() -> None:
             "runner must not install its own Node."
         )
 
-        resolve_step = next(
-            step
-            for step in steps
-            if step.get("name") == "Resolve IJT Browser CI image reference (digest-qualified)"
-        )
+        pull_step = steps[pull_index]
+        pull_body = pull_step["run"]
+        # Cache warm-up pull must consume the resolver's digest-qualified
+        # image_ref via env, never re-derive it from a tag.
         assert (
-            resolve_step.get("env", {}).get("PIN_PATH")
-            == ".github/docker/ijt-browser-ci/image-pin.json"
+            pull_step.get("env", {}).get("IMG")
+            == "${{ needs.resolve-browser-image.outputs.image_ref }}"
+        ), "Pull step must source IMG from the resolve-browser-image job output."
+        assert "@sha256:[0-9a-f]{64}" in pull_body, (
+            "Pull step must guard that IMG is digest-qualified."
         )
-        assert "^sha256:[0-9a-f]{64}$" in resolve_step["run"], (
-            "Resolve step must guard that the digest is sha256:<64hex>."
-        )
-        assert "PR_HEAD_SHA" in resolve_step["env"], (
-            "Resolve step must know the PR head SHA so browser-image-input PRs "
-            "can detect whether browser image inputs changed."
-        )
-        assert 'short_sha="${GITHUB_SHA::7}"' in resolve_step["run"]
-        assert '"$GITHUB_SHA"' in resolve_step["run"]
-        assert "trusted_dependency_bot" not in resolve_step["run"]
-        assert "browser_image_inputs_changed" in resolve_step["run"]
-        assert ".github/docker/ijt-browser-ci/*" in resolve_step["run"]
-        assert "OPC_UA_Clients/Release2/IJT_Web_Client/package-lock.json" in resolve_step["run"]
-        assert "PR-scoped browser image" in resolve_step["run"]
-        assert "main SHA browser image" in resolve_step["run"]
-        assert 'docker pull "$tag"' in resolve_step["run"]
-        assert "/opt/ijt-browser-ci/metadata.json" in resolve_step["run"]
-        assert "actual_sha" in resolve_step["run"]
-        assert "image_source=${image_source}" in resolve_step["run"]
+        assert 'docker pull "$IMG"' in pull_body
 
         login_step = next(
             step for step in steps if step.get("uses", "").startswith("docker/login-action@")
         )
         assert login_step.get("with", {}).get("registry") == "ghcr.io"
 
-        pull_step = next(
-            step
-            for step in steps
-            if step.get("name") == "Pull IJT Browser CI image (3-attempt retry)"
-        )
-        pull_body = pull_step["run"]
-        assert "docker pull" in pull_body
-        assert "source:   ${IMAGE_SOURCE}" in pull_body
-        assert "max_attempts=3" in pull_body, (
-            "Pull step must retry 3x; transient GHCR errors must not fail "
-            "the job on a single attempt."
-        )
-        assert "build-browser-ci-image.yml" in pull_body, (
-            "Pull step diagnostic must name the image-build workflow so operators can republish."
-        )
-        # Match the precise diagnostic phrase from integration.yml so this
-        # assertion can't be misread as URL-substring sanitization (CodeQL
-        # py/incomplete-url-substring-sanitization false-positive on the
-        # bare "ghcr.io" substring).
-        assert "ghcr.io (GHCR)" in pull_body, (
-            "Pull step diagnostic must name the registry as `ghcr.io (GHCR)` "
-            "so the operator immediately knows which registry failed."
-        )
-
         run_step = next(
             step
             for step in steps
             if step.get("name") == "Run Web Client browser e2e suite (offline, --network=none)"
+        )
+        # The image fed to docker run is the resolver's job output. Critical
+        # invariant: it does not come from a step-output produced inside this
+        # job (which is what enabled the historical race).
+        assert (
+            run_step.get("env", {}).get("IMG")
+            == "${{ needs.resolve-browser-image.outputs.image_ref }}"
+        ), (
+            "Run step's IMG must come from needs.resolve-browser-image.outputs.image_ref, "
+            "not from a step-output side effect."
         )
         run_body = run_step["run"]
         assert "docker run" in run_body


### PR DESCRIPTION
## Summary

Replaces cross-workflow GHCR tag polling for Browser CI image readiness with a single Integration-owned execution DAG.

Root cause of recurrent flake (run 26257538245 and prior): `Build Browser CI Image` and `Integration` ran as independent workflows synchronizing through GHCR tag presence with a fixed 10-minute consumer budget. On 2026-05-21 the producer pushed the expected tag ~1m43s after the consumer had already timed out. The race is a workflow design defect, not a SHA mismatch.

## What changes

1. Browser image production becomes a reusable workflow called from Integration via `workflow_call`.
2. New Integration jobs `prepare-browser-image-plan` -> conditional `build-browser-image` -> `resolve-browser-image` form an explicit DAG.
3. `live-webclient-browser` consumes `needs.resolve-browser-image.outputs.image_ref` (digest reference). No GHCR polling. No 10-minute blind wait.
4. `fingerprint-<hex>` GHCR cache tag added so repeated same-input Renovate PRs reuse an existing digest. Cache identity is `inputs_fingerprint`; runtime identity is `digest`. `GITHUB_SHA` is provenance only, not validated on consumer side.
5. Non-Browser Integration jobs remain fully parallel.

## Contract guarantees

- `tests/test_ci_synchronization_invariants.py` (new) asserts 8 architectural invariants including: no docker pull polling loop, `needs` edge to resolver, no `secrets: inherit` on the `workflow_call` site, fingerprint-cache tag publication, no SHA-equality consumer check.
- `tests/test_image_pin.py` and `tests/test_root_runner.py` rewritten to validate the new DAG instead of the old tag-polling shape.

## Validation

- `pre-commit run --all-files`: 19/19 hooks green (zizmor, actionlint, ruff, Bandit, ESLint, Stylelint, workflow-policy-guard with embedded pytest).
- `pytest --ignore=OPC_UA_Clients`: 338/338 pass.

## Scope boundary

This PR is one behavior-boundary commit on Browser CI synchronization only. Readiness-budget work for Security/Console/Test Client fixtures will land as a separate root-cause commit (Commit B), not bundled here.

## Expected behavior on this PR

Since no Browser CI image inputs changed on this branch, the planner should emit `plan=pin`, `build-browser-image` should be skipped, and `resolve-browser-image` should return the reviewed digest from `image-pin.json`.
