### PR TITLE
Commit B: Live-test readiness contract — protocol handshakes + compose healthchecks, no port-open guesses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,13 @@ OPC_UA_Clients/*
 OPC_UA_Clients/Release2/*
 !OPC_UA_Clients/Release2/IJT_Web_Client/**
 
+# Allow the shared readiness module to be vendored into the Web Client
+# Docker test image (see OPC_UA_Clients/Release2/IJT_Web_Client/Dockerfile,
+# test stage). tests/python/_live_server_readiness.py imports it at runtime.
+!scripts/
+scripts/*
+!scripts/ijt_live_readiness.py
+
 **/__pycache__/
 **/*.py[cod]
 **/.venv/

--- a/.github/workflows/build-browser-ci-image.yml
+++ b/.github/workflows/build-browser-ci-image.yml
@@ -84,7 +84,7 @@ env:
 
 jobs:
   build:
-    name: Build & Phase-0 smoke
+    name: Build and image smoke
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -205,7 +205,7 @@ jobs:
           file: .github/docker/ijt-browser-ci/Dockerfile
           load: true
           push: false
-          tags: ${{ env.IMAGE_NAME }}:phase0-${{ steps.decide.outputs.short_sha }}
+          tags: ${{ env.IMAGE_NAME }}:image-smoke-${{ steps.decide.outputs.short_sha }}
           build-args: |
             IMAGE_BUILD_REF=${{ github.ref }}
             IMAGE_BUILD_SHA=${{ steps.decide.outputs.source_sha }}
@@ -213,13 +213,13 @@ jobs:
           cache-from: type=gha,scope=ijt-browser-ci
           cache-to: type=gha,scope=ijt-browser-ci,mode=max
 
-      - name: Phase 0 smoke - metadata + tool versions
+      - name: Image smoke - metadata and tool versions
         env:
           SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
           EXPECTED_FINGERPRINT: ${{ steps.fingerprint.outputs.inputs_fingerprint }}
         run: |
           set -euo pipefail
-          IMG="${IMAGE_NAME}:phase0-${SHORT_SHA}"
+          IMG="${IMAGE_NAME}:image-smoke-${SHORT_SHA}"
           docker run --rm --network=none "$IMG" cat /opt/ijt-browser-ci/metadata.json
           docker run --rm --network=none "$IMG" bash -c 'python --version | grep -E "^Python 3\.14\."'
           docker run --rm --network=none "$IMG" bash -c 'node --version | grep -E "^v24\."'
@@ -228,18 +228,18 @@ jobs:
               python -c "import json; print(json.load(open('/opt/ijt-browser-ci/metadata.json')).get('inputs_fingerprint',''))"
           )"
           if [[ "$actual_fingerprint" != "$EXPECTED_FINGERPRINT" ]]; then
-            echo "::error::Phase 0 image metadata inputs_fingerprint does not match the source checkout." >&2
+            echo "::error::Image metadata inputs_fingerprint does not match the source checkout." >&2
             echo "::error::  expected: $EXPECTED_FINGERPRINT" >&2
             echo "::error::  actual:   ${actual_fingerprint}" >&2
             exit 1
           fi
 
-      - name: Phase 0 smoke - cache & permissions probe (non-root UID)
+      - name: Image smoke - cache and permissions probe (non-root UID)
         env:
           SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
         run: |
           set -euo pipefail
-          IMG="${IMAGE_NAME}:phase0-${SHORT_SHA}"
+          IMG="${IMAGE_NAME}:image-smoke-${SHORT_SHA}"
           UID_GID="$(id -u):$(id -g)"
           docker run --rm --network=none --user "$UID_GID" "$IMG" bash -c '
             set -euo pipefail
@@ -251,7 +251,7 @@ jobs:
             python -m venv /tmp/v && /tmp/v/bin/python -m pip --version
           '
 
-      - name: Phase 0 smoke - offline dependency closure probe
+      - name: Image smoke - offline dependency closure probe
         # Image-integrity gate only: prove the baked pip wheelhouse, npm cache,
         # Chromium install, and non-root permissions are usable with
         # --network=none. Full browser behavior stays in the post-publish
@@ -263,7 +263,7 @@ jobs:
           SHORT_SHA: ${{ steps.decide.outputs.short_sha }}
         run: |
           set -euo pipefail
-          IMG="${IMAGE_NAME}:phase0-${SHORT_SHA}"
+          IMG="${IMAGE_NAME}:image-smoke-${SHORT_SHA}"
           UID_GID="$(id -u):$(id -g)"
           docker run --rm \
             --network=none \
@@ -303,28 +303,28 @@ jobs:
               test -d /ms-playwright
             '
 
-      - name: Stage Phase 0 artifacts
+      - name: Stage image smoke artifacts
         if: always()
         run: |
           set -euxo pipefail
-          mkdir -p "${GITHUB_WORKSPACE}/.phase0-artifacts"
+          mkdir -p "${GITHUB_WORKSPACE}/.image-smoke-artifacts"
           for src in \
             "${GITHUB_WORKSPACE}/OPC_UA_Clients/Release2/IJT_Web_Client/test-results" \
             "${GITHUB_WORKSPACE}/test-results"; do
             if [[ -d "$src" ]]; then
-              dest="${GITHUB_WORKSPACE}/.phase0-artifacts/$(basename "$(dirname "$src")")-$(basename "$src")"
+              dest="${GITHUB_WORKSPACE}/.image-smoke-artifacts/$(basename "$(dirname "$src")")-$(basename "$src")"
               cp -r "$src" "$dest" || true
             fi
           done
-          ls -la "${GITHUB_WORKSPACE}/.phase0-artifacts" || true
+          ls -la "${GITHUB_WORKSPACE}/.image-smoke-artifacts" || true
 
-      - name: Upload Phase 0 artifacts
+      - name: Upload image smoke artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: phase0-${{ steps.decide.outputs.short_sha }}
+          name: image-smoke-${{ steps.decide.outputs.short_sha }}
           path: |
-            .phase0-artifacts/**
+            .image-smoke-artifacts/**
             OPC_UA_Clients/Release2/IJT_Web_Client/test-results/**
             test-results/**
           if-no-files-found: ignore
@@ -342,7 +342,7 @@ jobs:
         run: |
           set -euo pipefail
           {
-            echo "## IJT Browser CI image - Phase 0 build"
+            echo "## IJT Browser CI image - build and smoke"
             echo ""
             echo "- Event: \`${EVENT_NAME}\`"
             echo "- Ref: \`${REF}\`"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,26 +486,17 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Start Compose Stack
-        run: docker compose up -d --no-build
-
-      - name: Wait for HTTP Readiness
-        shell: bash
-        run: |
-          set -euo pipefail
-          for _i in {1..60}; do
-            if curl -fsS http://127.0.0.1:3000 >/dev/null; then
-              echo "HTTP endpoint is ready."
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Timed out waiting for http://127.0.0.1:3000"
-          docker ps
-          docker logs ijt_web_client || true
-          exit 1
+        # ``--wait --wait-timeout 120`` makes compose itself the synchronization
+        # primitive: the step exits success only after the ijt_web_client
+        # compose healthcheck (curl -f http://localhost:3000) reports healthy.
+        # 120s covers start_period 20s + interval 30s × retries 3 ≈ 110s budget
+        # with margin. Replaces the previous "up -d" + manual curl loop.
+        run: docker compose up -d --no-build --wait --wait-timeout 120
 
       - name: Verify WebSocket Port
         shell: bash
+        # The compose healthcheck only proves HTTP :3000 readiness. WebSocket
+        # :8001 is still gated separately until the healthcheck is expanded.
         run: |
           timeout 30 bash -c \
             'until (echo > /dev/tcp/127.0.0.1/8001) >/dev/null 2>&1; do sleep 1; done'
@@ -868,34 +859,16 @@ jobs:
           Write-Host "Extracted ZIP contents:"
           Get-ChildItem "OPC_UA_Servers\Release2\OPC_UA_IJT_Server_Simulator\" | Select-Object Name
 
-      - name: Start OPC UA Server (background)
-        run: |
-          $proc = Start-Process `
-            -FilePath "OPC_UA_Servers\Release2\OPC_UA_IJT_Server_Simulator\opcua_ijt_demo_application.exe" `
-            -WorkingDirectory "OPC_UA_Servers\Release2\OPC_UA_IJT_Server_Simulator\" `
-            -PassThru -WindowStyle Hidden
-          Write-Host "Server PID: $($proc.Id)"
-          echo "SERVER_PID=$($proc.Id)" >> $env:GITHUB_ENV
-
-      - name: Wait for OPC UA port 40451
-        run: |
-          $timeout = 60
-          $start   = Get-Date
-          while (((Get-Date) - $start).TotalSeconds -lt $timeout) {
-            if (Test-NetConnection -ComputerName localhost -Port 40451 `
-                  -InformationLevel Quiet -WarningAction SilentlyContinue) {
-              Write-Host "Port 40451 is open"
-              exit 0
-            }
-            Write-Host "Waiting for server..."
-            Start-Sleep -Seconds 3
-          }
-          Write-Host "ERROR: Timeout waiting for port 40451"
-          exit 1
-
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.14"
+
+      - name: Start OPC UA Server with HELLO readiness
+        working-directory: ${{ github.workspace }}
+        run: |
+          python scripts/start_server_on_port.py `
+            --port 40451 `
+            --diagnostics-dir test-results/readiness
 
       - name: Install smoke test dependencies
         run: pip install -c "${{ github.workspace }}/constraints.txt" -r OPC_UA_Servers/Release2/tests/requirements.txt
@@ -912,16 +885,15 @@ jobs:
         if: always()
         with:
           name: results-server-smoke
-          path: test-results/smoke.xml
+          path: |
+            test-results/smoke.xml
+            test-results/readiness/**
           retention-days: 14
 
       - name: Stop OPC UA Server
         if: always()
-        run: |
-          if ($env:SERVER_PID) {
-            Stop-Process -Id $env:SERVER_PID -Force -ErrorAction SilentlyContinue
-            Write-Host "OPC UA server stopped"
-          }
+        working-directory: ${{ github.workspace }}
+        run: python scripts/start_server_on_port.py --port 40451 --stop
 
   # ───────────────────────────────────────────────────────────────────────────
   # Combined Report — always runs after all jobs.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -241,19 +241,40 @@ jobs:
           echo "Container started"
 
       - name: Wait for OPC UA port 40451
-        # Linux binary starts in ~3 s; allow up to 60 s total.
+        # This job uses ``docker run -d`` rather than ``docker compose up``,
+        # and the opcua-ijt-server image is built just above without the
+        # compose-level healthcheck definition used by live-test jobs. The
+        # HELLO-handshake check below is the protocol readiness contract for
+        # this container path, so this step is stricter than TCP-port liveness
+        # alone.
         run: |
+          # First wait up to 60s for the TCP port to open (binary boot).
           for i in $(seq 1 12); do
             if nc -z localhost 40451 2>/dev/null; then
               echo "Port 40451 open after $((i * 5)) s"
-              exit 0
+              break
             fi
             echo "Waiting... attempt $i/12"
             sleep 5
+            if [ "$i" -eq 12 ]; then
+              echo "ERROR: TCP-port timeout — dumping container logs:"
+              docker logs opcua-server --tail 60
+              exit 1
+            fi
           done
-          echo "ERROR: Timeout — dumping container logs:"
-          docker logs opcua-server --tail 60
-          exit 1
+          # Then assert real OPC UA HELLO readiness via the shared probe so
+          # the smoke job benefits from the same readiness contract as the
+          # compose-driven live-test jobs.
+          python - <<'PY'
+          import sys
+          sys.path.insert(0, "scripts")
+          from ijt_live_readiness import wait_for_opcua_hello
+          result = wait_for_opcua_hello("localhost", 40451, timeout=30.0)
+          if not result.ok:
+              print(f"ERROR: OPC UA HELLO probe failed: {result.error}")
+              sys.exit(1)
+          print(f"OPC UA HELLO ack in {result.elapsed_seconds}s (attempts={result.attempts})")
+          PY
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
@@ -368,6 +389,11 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Start production container and verify HTTP health
+        # This job uses ``docker run -d`` rather than ``docker compose up``,
+        # and the production Web Client image is built just above without the
+        # compose-level healthcheck definition. The HTTP probe below is the
+        # readiness contract for this container path, and it is an
+        # application-protocol check rather than a TCP-port check.
         run: |
           docker run -d --name ijt-web-prod \
             -p 3000:3000 \
@@ -430,7 +456,10 @@ jobs:
 
       - name: Start OPC UA server on port 40462
         working-directory: ${{ github.workspace }}
-        run: python scripts/start_server_on_port.py --port 40462
+        run: |
+          python scripts/start_server_on_port.py `
+            --port 40462 `
+            --diagnostics-dir test-results/readiness
 
       - name: Run smoke test (quick server sanity check)
         env:
@@ -488,6 +517,7 @@ jobs:
             test-results/report.html
             test-results/report.xlsx
             test-results/summary.md
+            test-results/readiness/**
           retention-days: 14
 
       - name: Stop OPC UA server
@@ -916,7 +946,10 @@ jobs:
 
       - name: Start OPC UA server on port 40461
         working-directory: ${{ github.workspace }}
-        run: python scripts/start_server_on_port.py --port 40461
+        run: |
+          python scripts/start_server_on_port.py `
+            --port 40461 `
+            --diagnostics-dir OPC_UA_Clients/Release2/IJT_Console_Client/test-results/readiness
 
       - name: Run Console Client live tests
         working-directory: OPC_UA_Clients/Release2/IJT_Console_Client
@@ -973,7 +1006,10 @@ jobs:
 
       - name: Start OPC UA server on port 40464
         working-directory: ${{ github.workspace }}
-        run: python scripts/start_server_on_port.py --port 40464
+        run: |
+          python scripts/start_server_on_port.py `
+            --port 40464 `
+            --diagnostics-dir OPC_UA_Clients/Release2/IJT_CSharp_Client/test-results/readiness
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -116,8 +116,7 @@ test-results/
 playwright-report/
 *.[Tt][Mm][Pp]
 
-# Codex session temp manifests (codex_temp_cleanup.py creates these when
-# run with --root pointing at this repo; safe to leave gitignored globally)
+# Agent session temp manifests created by local cleanup and test tools.
 .codex_tmp/
 .codex_pytest_tmp/
 

--- a/OPC_UA_Clients/Release2/IJT_CSharp_Client/Tests/IJT_CSharp_Client.Tests/OpcUaServerFixture.cs
+++ b/OPC_UA_Clients/Release2/IJT_CSharp_Client/Tests/IJT_CSharp_Client.Tests/OpcUaServerFixture.cs
@@ -38,8 +38,15 @@ public sealed class OpcUaServerFixture : IDisposable
 {
     private const string DockerImageName = "opcua-ijt-server:latest";
     private const string LinuxSimulatorZipName = "OPC_UA_IJT_Server_Simulator_Linux.zip";
-    private const int DockerComposeCachedUpTimeoutMs = 30_000;
-    private const int DockerComposeBuildUpTimeoutMs = 300_000;
+    // Compose --wait-timeout budgets. The 120s warm value covers the OPC UA
+    // server compose healthcheck (nc -z, start_period 20s + interval 10s ×
+    // retries 6 ≈ 80s) with margin. The 300s cold value adds image build.
+    // These two are the only allowed compose --wait-timeout values for this
+    // test fixture.
+    private const int DockerComposeWarmWaitTimeoutSeconds = 120;
+    private const int DockerComposeColdWaitTimeoutSeconds = 300;
+    private const int DockerComposeCachedUpTimeoutMs = (DockerComposeWarmWaitTimeoutSeconds + 30) * 1000;
+    private const int DockerComposeBuildUpTimeoutMs = (DockerComposeColdWaitTimeoutSeconds + 60) * 1000;
     private const int DockerComposeOutputTailLimit = 80;
 
     private static readonly ILogger _log = IjtLog.ForCategory("IJT.Tests.ServerFixture");
@@ -221,8 +228,11 @@ public sealed class OpcUaServerFixture : IDisposable
         {
             if (TryLaunchViaDocker(knownX509UserCertificateDer))
             {
-                IsAvailable = WaitForPort(_port, timeoutSeconds: 60)
-                    && ProbeOpcUaReady(_port, maxAttempts: ProbeMaxAttempts(), delayMs: 1000);
+                // ``docker compose up --wait`` already blocked on the OPC UA
+                // server compose healthcheck (nc -z on the OPC UA port), so a
+                // raw TCP probe here would be redundant. The protocol probe
+                // alone is the readiness contract.
+                IsAvailable = ProbeOpcUaReady(_port, maxAttempts: ProbeMaxAttempts(), delayMs: 1000);
                 if (!IsAvailable)
                 {
                     var msg = $"[OpcUaServerFixture] Docker OPC UA server did not become ready on port {_port}.";
@@ -262,8 +272,10 @@ public sealed class OpcUaServerFixture : IDisposable
             // No native binary — try Docker fallback
             if (TryLaunchViaDocker(knownX509UserCertificateDer))
             {
-                IsAvailable = WaitForPort(_port, timeoutSeconds: 60)
-                    && ProbeOpcUaReady(_port, maxAttempts: ProbeMaxAttempts(), delayMs: 1000);
+                // ``docker compose up --wait`` already proved port-open via the
+                // compose healthcheck. Protocol probe is the single readiness
+                // invariant; do not gate it behind a redundant TCP probe.
+                IsAvailable = ProbeOpcUaReady(_port, maxAttempts: ProbeMaxAttempts(), delayMs: 1000);
                 if (!IsAvailable)
                 {
                     var msg = $"[OpcUaServerFixture] Docker OPC UA server did not become ready on port {_port}. Live tests will be skipped.";
@@ -333,24 +345,16 @@ public sealed class OpcUaServerFixture : IDisposable
             _serverProcess.BeginOutputReadLine();
             _serverProcess.BeginErrorReadLine();
 
-            // Step 3: wait for TCP port to open
-            var portOpen = WaitForPort(_port, timeoutSeconds: 30);
-            if (!portOpen)
-            {
-                _log.LogWarning("OPC UA server did not open TCP port {Port} within 30 s. Live tests will be skipped.", _port);
-                IsAvailable = false;
-                return;
-            }
-
-            // Step 4: OPC UA readiness probe — verify the process is alive and the OPC UA
+            // Step 3: OPC UA readiness probe — verify the process is alive and the OPC UA
             // service layer is accepting connections (not just TCP).  The server opens the
             // TCP listener before the OPC UA stack is fully initialised, so we retry with
-            // back-off rather than using a fixed sleep.
+            // back-off rather than using a fixed sleep. ProbeOpcUaReady includes its own
+            // attempts × delay budget, so a separate TCP-port wait would be redundant.
             var attempts = ProbeMaxAttempts();
             IsAvailable = ProbeOpcUaReady(_port, maxAttempts: attempts, delayMs: 1000);
             if (!IsAvailable)
             {
-                var probeMsg = $"[OpcUaServerFixture] Server on port {_port} opened TCP but did not accept OPC UA connections within timeout. Live tests will be skipped.";
+                var probeMsg = $"[OpcUaServerFixture] Server on port {_port} did not accept OPC UA connections within timeout. Live tests will be skipped.";
                 _log.LogWarning("{Message}", probeMsg);
                 Console.Error.WriteLine(probeMsg);
             }
@@ -570,6 +574,17 @@ public sealed class OpcUaServerFixture : IDisposable
             var wantsBuild = ShouldBuildDockerImage(dockerExe, composeDir);
             if (wantsBuild)
                 startInfo.ArgumentList.Add("--build");
+            // compose --wait makes Docker itself the synchronization primitive:
+            // the invocation blocks until the OPC UA server compose
+            // healthcheck (nc -z on the OPC UA port) reports healthy. Without
+            // this, "up -d" returned as soon as the container started and the
+            // caller had to poll, producing flaky readiness behaviour.
+            startInfo.ArgumentList.Add("--wait");
+            startInfo.ArgumentList.Add("--wait-timeout");
+            startInfo.ArgumentList.Add(
+                (wantsBuild
+                    ? DockerComposeColdWaitTimeoutSeconds
+                    : DockerComposeWarmWaitTimeoutSeconds).ToString(CultureInfo.InvariantCulture));
             var timeoutMs = DockerComposeUpTimeoutMs(wantsBuild);
 
             using var r = new Process
@@ -1219,16 +1234,12 @@ public sealed class OpcUaServerFixture : IDisposable
     }
 
 
-    private static bool WaitForPort(int port, int timeoutSeconds)
-    {
-        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
-        while (DateTime.UtcNow < deadline)
-        {
-            if (IsPortOpen(port)) return true;
-            Thread.Sleep(500);
-        }
-        return false;
-    }
+    // NOTE: Do not reintroduce a TCP-only ``WaitForPort`` readiness gate.
+    // After ``docker compose up --wait`` the compose healthcheck already
+    // proves the OPC UA TCP port is open; for the native-EXE path, the
+    // ProbeOpcUaReady retry loop spans the same window and is a strictly
+    // stronger guarantee. The live readiness contract forbids re-introducing
+    // a Thread.Sleep-based port wait alongside the protocol probe.
 
     private static bool WaitForPortClosed(int port, int timeoutSeconds)
     {

--- a/OPC_UA_Clients/Release2/IJT_Console_Client/tests/live/conftest.py
+++ b/OPC_UA_Clients/Release2/IJT_Console_Client/tests/live/conftest.py
@@ -24,7 +24,6 @@ import json
 import os
 import platform
 import shutil
-import socket
 import subprocess
 import sys
 import time
@@ -44,6 +43,20 @@ _CONSOLE_ROOT = _LIVE_DIR.parents[1]
 _REPO_ROOT = _LIVE_DIR.parents[4]
 _SERVER_RELEASE2 = _REPO_ROOT / "OPC_UA_Servers" / "Release2"
 _SERVER_DOCKER_IMAGE = "opcua-ijt-server:latest"
+
+# The shared readiness module lives at ``<repo>/scripts/ijt_live_readiness.py``.
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if _SCRIPTS_DIR.is_dir() and str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from ijt_live_readiness import (  # noqa: E402
+    COMPOSE_WAIT_TIMEOUT_COLD_SECONDS,
+    COMPOSE_WAIT_TIMEOUT_WARM_SECONDS,
+    capture_compose_logs_on_failure,
+    wait_for_opcua_hello,
+    wait_for_tcp,
+)
+
 _SERVER_LINUX_ZIP = _SERVER_RELEASE2 / "OPC_UA_IJT_Server_Simulator_Linux.zip"
 _SERVER_ZIP = _SERVER_RELEASE2 / "OPC_UA_IJT_Server_Simulator.zip"
 _SERVER_DIR = _SERVER_RELEASE2 / "OPC_UA_IJT_Server_Simulator"
@@ -54,6 +67,18 @@ _CLIENT_PKI_ROOT = _CONSOLE_ROOT / "tmp" / "client-pki"
 _DOCKER_OVERRIDE_ROOT = _CONSOLE_ROOT / "tmp" / "docker-overrides"
 
 _OPCUA_PORT = 40451
+
+# Readiness diagnostics (compose-log capture on failure) are written next to
+# pytest test-results so the Console Live integration job's
+# ``upload-artifact: test-results/`` step picks them up automatically.
+_READINESS_DIAGNOSTICS_DIR = _CONSOLE_ROOT / "test-results" / "readiness"
+
+
+def _console_readiness_diagnostics_dir() -> Path:
+    """Return the directory under ``test-results/`` where compose-log capture
+    and any future readiness diagnostics should land."""
+    return _READINESS_DIAGNOSTICS_DIR
+
 
 sys.path.insert(0, str(_CONSOLE_ROOT))
 
@@ -98,11 +123,7 @@ def _resolve_server_host_port() -> tuple[str, int]:
 
 
 def _port_open(host: str, port: int, timeout: float = 1.5) -> bool:
-    try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except OSError:
-        return False
+    return wait_for_tcp(host, port, timeout=timeout, interval=timeout, connect_timeout=timeout).ok
 
 
 def _isolated_server_requested() -> bool:
@@ -202,49 +223,15 @@ def _kill_process_on_port(port: int) -> None:
             )
 
 
-def _wait_for_port(host: str, port: int, timeout: float, interval: float = 1.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if _port_open(host, port):
-            return True
-        time.sleep(interval)
-    return False
-
-
 def _wait_for_opcua_hello(host: str, port: int, timeout: float) -> bool:
     """Confirm an OPC UA server (not just an open TCP port) is reachable.
 
-    Sends a minimal OPC UA HELLO message and waits for ACK / ERR. This guards
-    against the docker-proxy race where the published TCP port opens before
-    the in-container server is ready to respond to UA HELLO, which previously
-    caused the first matrix test to time out in ``send_hello``.
+    Delegates to the shared readiness module so the Console fixture, the C#
+    fixture, ``scripts/start_server_on_port.py``, and the Web Client all use
+    one binary-protocol HELLO probe.
     """
 
-    endpoint_url = f"opc.tcp://{host}:{port}".encode("ascii")
-    url_len = len(endpoint_url)
-    total_len = 32 + url_len
-    hello = b"HELF" + total_len.to_bytes(4, "little")
-    hello += (0).to_bytes(4, "little")  # protocol version
-    hello += (65536).to_bytes(4, "little")  # receive buffer size
-    hello += (65536).to_bytes(4, "little")  # send buffer size
-    hello += (0).to_bytes(4, "little")  # max message size
-    hello += (0).to_bytes(4, "little")  # max chunk count
-    hello += url_len.to_bytes(4, "little")
-    hello += endpoint_url
-
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=3) as sock:
-                sock.settimeout(3)
-                sock.sendall(hello)
-                header = sock.recv(8)
-                if len(header) >= 4 and header[:3] in (b"ACK", b"ERR"):
-                    return True
-        except (OSError, socket.timeout):
-            pass
-        time.sleep(1.0)
-    return False
+    return wait_for_opcua_hello(host, port, timeout=timeout).ok
 
 
 # ── Server launcher ───────────────────────────────────────────────────────────
@@ -434,18 +421,49 @@ def _start_docker_server(port: int) -> StartedServer | None:
         _allow_container_write(pki_dir)
         override_file = _write_docker_compose_override(override_dir, pki_dir)
         compose_args.extend(["-f", str(compose_file), "-f", str(override_file)])
-    compose_args.extend(["up", "-d"])
+    compose_args.extend(["up", "-d", "--wait", "--wait-timeout", str(COMPOSE_WAIT_TIMEOUT_WARM_SECONDS)])
+    wait_budget_seconds = COMPOSE_WAIT_TIMEOUT_WARM_SECONDS
     if _should_build_docker_image(docker):
         compose_args.append("--build")
-    result = subprocess.run(
-        compose_args,
-        cwd=str(_SERVER_RELEASE2),
-        env=env,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
+        # Cold build path: replace the warm budget with the cold budget.
+        idx = compose_args.index("--wait-timeout")
+        compose_args[idx + 1] = str(COMPOSE_WAIT_TIMEOUT_COLD_SECONDS)
+        wait_budget_seconds = COMPOSE_WAIT_TIMEOUT_COLD_SECONDS
+    # Outer subprocess timeout = compose --wait-timeout budget + 60s slack for
+    # the docker CLI / daemon / image pull itself (--wait-timeout only bounds
+    # the healthcheck poll, not docker build or registry I/O).
+    outer_timeout = wait_budget_seconds + 60
+    diagnostics_dir = _console_readiness_diagnostics_dir()
+    try:
+        result = subprocess.run(
+            compose_args,
+            cwd=str(_SERVER_RELEASE2),
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=outer_timeout,
+        )
+    except subprocess.TimeoutExpired:
+        # Compose itself hung past the outer ceiling — capture logs and abort
+        # the auto-start path so live tests fail loudly instead of silently
+        # waiting forever.
+        capture_compose_logs_on_failure(
+            diagnostics_dir,
+            _SERVER_RELEASE2,
+            "opcua-server",
+            project=project,
+            docker_executable=docker,
+        )
+        return None
     if result.returncode != 0:
+        capture_compose_logs_on_failure(
+            diagnostics_dir,
+            _SERVER_RELEASE2,
+            "opcua-server",
+            project=project,
+            docker_executable=docker,
+        )
         if not preserve_test_artifacts():
             for path in (override_dir, pki_dir):
                 if path is not None:
@@ -534,18 +552,12 @@ def ensure_opcua_server():
         server = _start_opcua_server(port)
         if server:
             started_server = server
-            if not _wait_for_port(host, port, timeout=60):
+            if not _wait_for_opcua_hello(host, port, timeout=60):
                 _stop_opcua_server(server)
                 pytest.fail(
-                    f"OPC UA server process started but port {port} did not open within 60 s. "
-                    f"Check opcua_ijt_demo_application.exe output."
-                )
-            if not _wait_for_opcua_hello(host, port, timeout=30):
-                _stop_opcua_server(server)
-                pytest.fail(
-                    f"OPC UA TCP port {port} is open but the server did not respond to a "
-                    f"HELLO handshake within 30 s. The container/process may still be "
-                    f"warming up."
+                    f"OPC UA server process/container started but did not respond to a "
+                    f"HELLO handshake on {host}:{port} within 60 s. Check server output "
+                    f"or readiness diagnostics."
                 )
         else:
             pytest.fail(
@@ -555,6 +567,12 @@ def ensure_opcua_server():
             )
     elif isolated_server:
         pytest.fail(f"OPC UA port {port} is already in use and could not be cleared for an isolated managed run.")
+    elif not _wait_for_opcua_hello(host, port, timeout=30):
+        pytest.fail(
+            f"OPC UA TCP port {port} is open, but the server did not answer a "
+            f"HELLO handshake within 30 s. Start a real OPC UA simulator or "
+            f"free the stale port before running live tests."
+        )
 
     os.environ.setdefault("OPCUA_SERVER_URL", f"opc.tcp://{host}:{port}")
 

--- a/OPC_UA_Clients/Release2/IJT_Console_Client/tests/unit/test_coverage_phase5.py
+++ b/OPC_UA_Clients/Release2/IJT_Console_Client/tests/unit/test_coverage_phase5.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-"""Phase 5 coverage push — targeted tests for remaining gaps.
+"""Targeted coverage tests for remaining gaps.
 
 Targets:
 - event_handler.py:122-123 (CancelledError pass)

--- a/OPC_UA_Clients/Release2/IJT_Test_Client/helpers/server_manager.py
+++ b/OPC_UA_Clients/Release2/IJT_Test_Client/helpers/server_manager.py
@@ -7,54 +7,55 @@ Supports two workflows:
 Only terminates the simulator process if this manager started it.
 """
 
-import asyncio
 import logging
 import os
-import socket
 import subprocess  # nosec B404
 import sys
-import time
 from pathlib import Path
 from typing import Optional
 
 # Bandit B404/B603 suppressions are limited to controlled simulator process launch paths.
 
+# The shared readiness module lives at ``<repo>/scripts/ijt_live_readiness.py``.
+# Add the repo's ``scripts`` directory to sys.path explicitly so the import
+# works from the Test Client's run_all_tests.py and pytest entry points
+# regardless of caller cwd.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if _SCRIPTS_DIR.is_dir() and str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from ijt_live_readiness import (  # noqa: E402
+    wait_for_opcua_session,
+    wait_for_tcp,
+)
+
 logger = logging.getLogger(__name__)
 
 
 def is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
-    """Return True if a TCP connection to host:port succeeds within *timeout* seconds."""
-    try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except (socket.timeout, ConnectionRefusedError, OSError):  # fmt: skip
-        return False
+    """Return True if a TCP connection to host:port succeeds within *timeout* seconds.
+
+    Delegates to the shared readiness module so all live-test callers share a
+    single TCP-open implementation. Single-shot semantics preserved by passing
+    ``timeout`` as both the connect timeout AND the wait budget.
+    """
+
+    result = wait_for_tcp(host, port, timeout=timeout, interval=timeout, connect_timeout=timeout)
+    return result.ok
 
 
 def wait_for_port(host: str, port: int, timeout_s: float = 30.0) -> bool:
     """
     Poll host:port until it accepts connections or *timeout_s* elapses.
     Returns True if the port opened within the timeout, False otherwise.
+
+    Thin wrapper around the shared ``wait_for_tcp`` to preserve the existing
+    boolean API used by ``ServerManager.ensure_running``. New callers should
+    use ``wait_for_tcp`` directly to access the structured ReadinessResult.
     """
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if is_port_open(host, port):
-            return True
-        time.sleep(0.5)
-    return False
 
-
-async def _opcua_probe(url: str, timeout: float) -> bool:
-    """Attempt a real OPC UA connect/disconnect with a short timeout."""
-    from asyncua import Client
-
-    client = Client(url, timeout=timeout)
-    try:
-        await asyncio.wait_for(client.connect(), timeout=timeout)
-        await client.disconnect()
-        return True
-    except Exception:
-        return False
+    return wait_for_tcp(host, port, timeout=timeout_s, interval=0.5).ok
 
 
 def wait_for_opcua_ready(url: str, timeout_s: float = 30.0) -> bool:
@@ -64,19 +65,14 @@ def wait_for_opcua_ready(url: str, timeout_s: float = 30.0) -> bool:
     stack may still be initialising after the port becomes reachable.
     Returns True if the server accepted an OPC UA connection within the
     timeout, False otherwise.
+
+    Implementation note: delegates to the shared asyncua session probe
+    so the connect/disconnect contract matches the Web Client live conftest
+    and the Console Client live conftest's HELLO probe; "ready" means the
+    same thing for every IJT client.
     """
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        remaining = deadline - time.monotonic()
-        probe_timeout = min(3.0, max(0.5, remaining))
-        try:
-            ready = asyncio.run(_opcua_probe(url, probe_timeout))
-            if ready:
-                return True
-        except Exception as exc:
-            logger.debug("OPC UA probe attempt failed: %s", exc)
-        time.sleep(0.5)
-    return False
+
+    return wait_for_opcua_session(url, timeout=timeout_s, interval=0.5).ok
 
 
 def _find_server_executable() -> Optional[str]:

--- a/OPC_UA_Clients/Release2/IJT_Test_Client/scripts/make_conformance_summary.py
+++ b/OPC_UA_Clients/Release2/IJT_Test_Client/scripts/make_conformance_summary.py
@@ -13,10 +13,10 @@ Writes: $GITHUB_STEP_SUMMARY      (GitHub markdown step summary, if env var is s
 
 Called automatically by the CI workflow after the test run. Safe to run locally too.
 
-Phase 1 of the IJT CI / System Tests reporting overhaul moved the entire
-Markdown rendering pipeline into ``scripts/reporting/conformance_summary.py``
-so it can be tested independently. This module is now the CLI shim that
-parses arguments, reads test artifacts, calls
+The Markdown rendering pipeline lives in
+``scripts/reporting/conformance_summary.py`` so it can be tested
+independently. This module is the CLI shim that parses arguments, reads test
+artifacts, calls
 ``render_conformance_summary(...)``, and writes the result to disk and to the
 GitHub step summary. The shim re-exports a ``_render`` symbol that delegates
 to the new renderer purely for backward compatibility with any historical

--- a/OPC_UA_Clients/Release2/IJT_Test_Client/scripts/reporting/conformance_summary.py
+++ b/OPC_UA_Clients/Release2/IJT_Test_Client/scripts/reporting/conformance_summary.py
@@ -1,10 +1,9 @@
 """Conformance summary renderer for the IJT Test Client.
 
 This module owns the Markdown rendering pipeline that produces the
-`IJT Conformance Test Report` written by `make_conformance_summary.py`. It was
-extracted from that script (then named `make_ci_summary.py`) in Phase 1 of the IJT CI / System
-Tests reporting overhaul to keep the rendering logic separately
-testable (`tests/unit/reporting/test_render_conformance_summary.py`).
+`IJT Conformance Test Report` written by `make_conformance_summary.py`. The
+rendering logic lives here so it can be tested separately by
+`tests/unit/reporting/test_render_conformance_summary.py`.
 
 The public entry point is `render_conformance_summary(...)`. Its
 signature mirrors the original `_render(...)` so the surrounding CLI

--- a/OPC_UA_Clients/Release2/IJT_Web_Client/Dockerfile
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/Dockerfile
@@ -45,6 +45,13 @@ ENV NODE_ENV=development
 RUN pip install --no-cache-dir -c /tmp/constraints.txt -r requirements-dev.txt && \
     (npm ci --no-audit --no-fund || npm install --legacy-peer-deps --no-audit --no-fund)
 
+# Vendor the shared readiness module so tests/python/_live_server_readiness.py
+# can import ``ijt_live_readiness`` inside the Docker test container. The
+# build context is the repo root (see CI step), so the source path is
+# scripts/ijt_live_readiness.py and the target matches the helper's Docker
+# fallback path at /app/scripts/ijt_live_readiness.py.
+COPY scripts/ijt_live_readiness.py /app/scripts/ijt_live_readiness.py
+
 COPY OPC_UA_Clients/Release2/IJT_Web_Client/. .
 
 CMD ["python", "-m", "pytest", "tests/python/unit/", "-v", "--tb=short", "--no-header"]

--- a/OPC_UA_Clients/Release2/IJT_Web_Client/run_all_tests.py
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/run_all_tests.py
@@ -1749,6 +1749,42 @@ def _stage_infra_lint() -> StageResult:
 # ---------------------------------------------------------------------------
 _SERVER_COMPOSE_DIR = ROOT.parent.parent.parent / "OPC_UA_Servers" / "Release2"
 
+
+def _capture_compose_failure_logs(
+    compose_dir: Path,
+    *,
+    service: str,
+    docker: str,
+    label: str,
+) -> None:
+    """Best-effort capture of compose logs into ``test-results/readiness/``.
+
+    Delegates to :func:`ijt_live_readiness.capture_compose_logs_on_failure`
+    so every IJT compose-up callsite captures failure logs identically. The
+    diagnostics file lands under the Web Client's ``test-results/`` tree,
+    which is already covered by the integration workflow upload step.
+    """
+    try:
+        # The shared readiness module is stdlib-only at module scope, but
+        # importing it here defers any sys.path manipulation until we
+        # actually need the helper.
+        scripts_dir = _REPO_ROOT / "scripts"
+        if scripts_dir.is_dir() and str(scripts_dir) not in sys.path:
+            sys.path.insert(0, str(scripts_dir))
+        from ijt_live_readiness import (  # noqa: PLC0415 — deferred import
+            capture_compose_logs_on_failure,
+        )
+    except ImportError:  # pragma: no cover — defensive only
+        return
+    diag_dir = ROOT / "test-results" / "readiness"
+    capture_compose_logs_on_failure(
+        diag_dir,
+        compose_dir,
+        f"{service}-{label}",
+        docker_executable=docker,
+    )
+
+
 _WINDOWS_SIMULATOR_EXE = _SERVER_COMPOSE_DIR / "OPC_UA_IJT_Server_Simulator" / "opcua_ijt_demo_application.exe"
 _LINUX_SIMULATOR_EXE = _SERVER_COMPOSE_DIR / "OPC_UA_IJT_Server_Simulator_Linux" / "opcua_ijt_demo_application"
 _WINDOWS_SIMULATOR_ZIP = _SERVER_COMPOSE_DIR / "OPC_UA_IJT_Server_Simulator.zip"
@@ -2240,28 +2276,46 @@ def _maybe_start_opcua_server() -> tuple[bool, bool, subprocess.Popen | None]:
         return False, False, None
 
     _info(f"Launching OPC UA Docker server from {compose_dir}")
-    rc = _run([docker, "compose", "up", "-d"], cwd=compose_dir, label="docker compose up -d  (OPC UA server)")
+    rc = _run(
+        [
+            docker,
+            "compose",
+            "up",
+            "-d",
+            "--wait",
+            "--wait-timeout",
+            "120",
+        ],
+        cwd=compose_dir,
+        label="docker compose up -d --wait  (OPC UA server)",
+        # Outer timeout = compose --wait-timeout budget (120s) + 60s slack
+        # for docker CLI / daemon / image pull I/O. ``--wait-timeout`` only
+        # bounds the healthcheck poll itself, not the docker engine.
+        timeout=120 + 60,
+    )
     if rc != 0:
         _warn("docker compose up failed for OPC UA server")
+        _capture_compose_failure_logs(
+            compose_dir,
+            service="opcua-server",
+            docker=docker,
+            label="opcua-server-compose-up",
+        )
         return True, False, None
 
-    _info(f"Waiting up to 60s for OPC UA port {port} ...")
-    for _ in range(30):
-        if _port_open("localhost", port, timeout=1.0):
-            endpoint = _default_opcua_endpoint(port)
-            probe_error = _probe_opcua_protocol(endpoint)
-            if probe_error is not None:
-                _warn(f"OPC UA Docker server port {port} opened, but protocol readiness failed: {probe_error}")
-                _stop_opcua_server(None)
-                return True, False, None
-            _ok(f"OPC UA server ready on :{port}")
-            _set_opcua_test_endpoint(port)
-            _set_opcua_prestarted_port(port)
-            return True, True, None
-        time.sleep(2)
-
-    _warn(f"OPC UA server not ready after 60s (port {port})")
-    return True, False, None
+    # docker compose --wait blocked until the OPC UA server compose healthcheck
+    # (nc -z on the OPC UA port) passed. Re-verify protocol readiness because
+    # the healthcheck only proves TCP-port liveness, not OPC UA handshake.
+    endpoint = _default_opcua_endpoint(port)
+    probe_error = _probe_opcua_protocol(endpoint)
+    if probe_error is not None:
+        _warn(f"OPC UA Docker server port {port} healthchecked, but protocol readiness failed: {probe_error}")
+        _stop_opcua_server(None)
+        return True, False, None
+    _ok(f"OPC UA server ready on :{port}")
+    _set_opcua_test_endpoint(port)
+    _set_opcua_prestarted_port(port)
+    return True, True, None
 
 
 def _stop_opcua_server(proc: subprocess.Popen | None = None) -> None:
@@ -2522,18 +2576,28 @@ def _stage_docker_smoke() -> StageResult:
     if rc != 0:
         return StageResult("docker-smoke", rc, duration=time.monotonic() - t0, notes=["docker build failed"])
 
-    rc = _run(compose_cmd + ["up", "-d"], label="docker compose up -d")
+    rc = _run(
+        compose_cmd + ["up", "-d", "--wait", "--wait-timeout", "120"],
+        label="docker compose up -d --wait",
+        # Outer subprocess timeout: see _start_opcua_docker_server above. We
+        # bound the whole compose-up call to (--wait-timeout + 60s docker
+        # slack) so a hung daemon or pull cannot freeze docker-smoke.
+        timeout=120 + 60,
+    )
     if rc != 0:
+        _capture_compose_failure_logs(
+            ROOT,
+            service="ijt_web_client",
+            docker=compose_cmd[0],
+            label="ijt-web-compose-up",
+        )
         return StageResult("docker-smoke", rc, duration=time.monotonic() - t0, notes=["docker compose up failed"])
 
-    # Wait up to _DOCKER_TIMEOUT seconds for HTTP readiness (1 poll per second).
-    _info(f"Waiting up to {_DOCKER_TIMEOUT} s for http://127.0.0.1:3000 ...")
-    ready = False
-    for _ in range(_DOCKER_TIMEOUT):
-        if _port_open("127.0.0.1", 3000, timeout=1.0):
-            ready = True
-            break
-        time.sleep(1)
+    # docker compose --wait blocked until the Web Client compose healthcheck
+    # (curl -f http://localhost:3000) reported healthy, so HTTP readiness is
+    # already proven by the time we get here. Probe the WebSocket port only;
+    # the backend's WS readiness is not part of the compose healthcheck.
+    ready = _port_open("127.0.0.1", 3000, timeout=2.0)
 
     ws_ready = _port_open("127.0.0.1", 8001, timeout=2.0)
 

--- a/OPC_UA_Clients/Release2/IJT_Web_Client/tests/python/_live_server_readiness.py
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/tests/python/_live_server_readiness.py
@@ -1,14 +1,60 @@
-"""Shared live-test startup diagnostics and protocol readiness probes."""
+"""Shared live-test startup diagnostics and protocol readiness probes.
+
+Web Client adapter over the repository-wide readiness module at
+``scripts/ijt_live_readiness.py``. The functions ``wait_for_opcua_protocol_ready``
+and ``wait_for_websocket_protocol_ready`` keep their existing call signatures
+(returning ``str | None`` so they compose with existing callers) and own the
+per-attempt retry policy; the inner per-attempt probe (one
+asyncua connect+disconnect, one WebSocket handshake) is delegated to the
+shared probe-once helpers so the protocol-readiness contract is identical
+across all IJT clients. This file remains the home for Web-specific helpers
+(log paths, failure-signature extraction, ``start_process_with_opcua_logs``)
+that are not generally useful outside the Web Client tree.
+"""
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import json
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
+
+
+# Locate the shared readiness module robustly. In a normal repo checkout the
+# repo root is five ``parents`` up, but Docker test images flatten the tree
+# (the Web Client subtree alone is copied into /app), so we walk ancestors
+# looking for ``scripts/ijt_live_readiness.py`` and fall back to a vendored
+# copy at ``/app/scripts/ijt_live_readiness.py`` for the Docker test target.
+def _find_shared_readiness_scripts_dir() -> Path | None:
+    here = Path(__file__).resolve()
+    for ancestor in (here, *here.parents):
+        candidate = ancestor / "scripts" / "ijt_live_readiness.py"
+        if candidate.is_file():
+            return candidate.parent
+    # Docker test image layout: Web Client subtree is copied to /app, and
+    # the shared script is copied alongside as /app/scripts/...
+    docker_candidate = Path("/app/scripts/ijt_live_readiness.py")
+    if docker_candidate.is_file():
+        return docker_candidate.parent
+    return None
+
+
+_SCRIPTS_DIR = _find_shared_readiness_scripts_dir()
+if _SCRIPTS_DIR is not None and str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from ijt_live_readiness import (  # noqa: E402
+    opcua_session_probe_once,
+    websocket_probe_once,
+)
+
+# Module-level sleep indirection so tests can monkeypatch retry pacing without
+# stubbing the global ``time`` module. The retry loop below must call
+# ``_sleep`` rather than ``time.sleep`` directly so unit tests can assert on
+# inter-attempt waits.
+_sleep = time.sleep
 
 OPCUA_PRESTARTED_PORT_ENV = "IJT_OPCUA_PRESTARTED_PORT"
 MAX_SIMULATOR_LAUNCH_ATTEMPTS = 2
@@ -26,6 +72,16 @@ DEFAULT_PROTOCOL_READY_TIMEOUT = 2.5
 DEFAULT_WEBSOCKET_READY_ATTEMPTS = 1
 DEFAULT_WEBSOCKET_READY_INTERVAL = 1.0
 DEFAULT_WEBSOCKET_READY_RESPONSE_TIMEOUT = 5.0
+
+# The Web Client backend's readiness-probe handshake. ``get connectionpoints``
+# is a stateless, side-effect-free command handled directly by
+# ``handle_get_connection_points`` in ``src/python/ijt_interface.py``. What we
+# are checking is that the WS plumbing reaches the backend dispatcher and the
+# reply carries our ``uniqueid``.
+_WEB_BACKEND_READINESS_COMMAND = "get connectionpoints"
+_WEB_BACKEND_READINESS_ENDPOINT = "common"
+_WEB_BACKEND_READINESS_UNIQUEID = "readiness-probe"
+
 _KNOWN_FAILURE_SIGNATURES: tuple[str, ...] = (
     "0x80010000",
     "CoInitialize",
@@ -36,7 +92,6 @@ _KNOWN_FAILURE_SIGNATURES: tuple[str, ...] = (
 )
 _FAILURE_SIGNATURE_TAIL_LINES = 40
 _FAILURE_SIGNATURE_TAIL_BYTES = 8192
-_sleep = time.sleep
 
 
 def _tail_log_lines(path: Path, *, max_lines: int, max_bytes: int) -> list[str]:
@@ -114,17 +169,6 @@ def start_process_with_opcua_logs(
         err_file.close()
 
 
-async def _probe_opcua_protocol(endpoint: str, connect_timeout: float) -> None:
-    from asyncua import Client
-
-    client = Client(endpoint, timeout=connect_timeout)
-    try:
-        await client.connect()
-    finally:
-        with contextlib.suppress(Exception):
-            await client.disconnect()
-
-
 def wait_for_opcua_protocol_ready(
     endpoint: str,
     *,
@@ -132,57 +176,25 @@ def wait_for_opcua_protocol_ready(
     interval: float = DEFAULT_PROTOCOL_READY_INTERVAL,
     connect_timeout: float = DEFAULT_PROTOCOL_READY_TIMEOUT,
 ) -> str | None:
-    last_error = "no OPC UA protocol probe attempted"
-    for attempt in range(attempts):
-        try:
-            asyncio.run(_probe_opcua_protocol(endpoint, connect_timeout))
+    """Wait until ``endpoint`` accepts an asyncua connect+disconnect.
+
+    Returns ``None`` on success, a single-line error string on failure (kept
+    for backwards compatibility with callers that distinguish probe types by
+    error-string substring matching). Each attempt delegates to
+    :func:`ijt_live_readiness.opcua_session_probe_once` so the per-attempt
+    contract is shared with the rest of the IJT clients; this wrapper owns
+    the retry loop (``attempts`` × ``interval``) so its tests can monkeypatch
+    ``_sleep``.
+    """
+
+    last_error: str | None = None
+    for index in range(attempts):
+        last_error = opcua_session_probe_once(endpoint, connect_timeout=connect_timeout)
+        if last_error is None:
             return None
-        except Exception as exc:  # pragma: no cover - exact asyncua exception type varies by version
-            last_error = f"{type(exc).__name__}: {exc}"
-            if attempt < attempts - 1:
-                _sleep(interval)
+        if index < attempts - 1:
+            _sleep(interval)
     return last_error
-
-
-async def _probe_websocket_protocol(ws_url: str, response_timeout: float) -> None:
-    import websockets
-
-    async with websockets.connect(ws_url, open_timeout=min(5.0, response_timeout), close_timeout=0.5) as websocket:
-        uniqueid = "readiness-probe"
-        await websocket.send(
-            json.dumps(
-                {
-                    "command": "get connectionpoints",
-                    "endpoint": "common",
-                    "uniqueid": uniqueid,
-                }
-            )
-        )
-        deadline = asyncio.get_running_loop().time() + response_timeout
-        last_response = "no response received"
-        unmatched_count = 0
-        while True:
-            remaining = deadline - asyncio.get_running_loop().time()
-            if remaining <= 0:
-                raise TimeoutError(f"no matching readiness response received; last response: {last_response}")
-            try:
-                raw = await asyncio.wait_for(websocket.recv(), timeout=remaining)
-            except TimeoutError as exc:
-                raise TimeoutError(
-                    f"no matching readiness response received within {response_timeout:.1f}s; "
-                    f"last response: {last_response}"
-                ) from exc
-            last_response = str(raw)
-            try:
-                payload = json.loads(raw)
-            except json.JSONDecodeError as exc:
-                raise RuntimeError(f"invalid readiness response JSON: {exc.msg}") from exc
-            if payload.get("uniqueid") != uniqueid:
-                unmatched_count += 1
-                if unmatched_count >= 5:
-                    raise RuntimeError(f"no matching readiness response received; last response: {last_response}")
-                continue
-            return
 
 
 def wait_for_websocket_protocol_ready(
@@ -193,13 +205,44 @@ def wait_for_websocket_protocol_ready(
     interval: float = DEFAULT_WEBSOCKET_READY_INTERVAL,
     response_timeout: float = DEFAULT_WEBSOCKET_READY_RESPONSE_TIMEOUT,
 ) -> str | None:
-    last_error = "no WebSocket protocol probe attempted"
-    for attempt in range(attempts):
-        try:
-            asyncio.run(_probe_websocket_protocol(ws_url, response_timeout))
+    """Wait until the WebSocket backend completes the IJT readiness handshake.
+
+    Returns ``None`` on success, an error string on failure. Sends the
+    legacy IJT readiness payload
+    ``{"command": "get connectionpoints", "endpoint": "common", "uniqueid":
+    "readiness-probe"}`` and treats any reply carrying ``uniqueid =
+    "readiness-probe"`` as success (the backend may answer with normal data
+    or with ``{"exception": "..."}``; both prove the WS plumbing works).
+    The per-attempt probe is delegated to
+    :func:`ijt_live_readiness.websocket_probe_once`; this wrapper owns the
+    retry loop so its tests can monkeypatch ``_sleep``.
+
+    ``opcua_endpoint`` is accepted for backwards-compatibility with older
+    callers; the readiness probe itself does not address a specific OPC UA
+    endpoint (it asks the backend for its connection-points table, which is
+    OPC-UA-independent).
+    """
+
+    del opcua_endpoint  # kept in the signature for backwards compatibility
+    payload_json = json.dumps(
+        {
+            "command": _WEB_BACKEND_READINESS_COMMAND,
+            "endpoint": _WEB_BACKEND_READINESS_ENDPOINT,
+            "uniqueid": _WEB_BACKEND_READINESS_UNIQUEID,
+        }
+    )
+    last_error: str | None = None
+    for index in range(attempts):
+        last_error = websocket_probe_once(
+            ws_url,
+            payload_json=payload_json,
+            handshake_id=_WEB_BACKEND_READINESS_UNIQUEID,
+            open_timeout=response_timeout,
+            close_timeout=0.5,
+            response_timeout=response_timeout,
+        )
+        if last_error is None:
             return None
-        except Exception as exc:  # pragma: no cover - exact backend/websocket error type varies by version
-            last_error = f"{type(exc).__name__}: {exc}"
-            if attempt < attempts - 1:
-                _sleep(interval)
+        if index < attempts - 1:
+            _sleep(interval)
     return last_error

--- a/OPC_UA_Clients/Release2/IJT_Web_Client/tests/python/unit/test_static_analysis.py
+++ b/OPC_UA_Clients/Release2/IJT_Web_Client/tests/python/unit/test_static_analysis.py
@@ -26,14 +26,23 @@ _SRC_PYTHON = _PROJECT_ROOT / "src" / "python"
 
 _SKIP_DIRS = {"__pycache__", "node_modules", ".git", ".state"}
 
+# Files vendored into the Docker test image from outside the Web Client tree.
+# These are owned and tested by their canonical location (repo-root
+# ``scripts/`` and ``tests/``) and must not be re-analyzed under the Web
+# Client's project-scoped static-analysis sweep. Outside Docker the
+# Web Client _PROJECT_ROOT does not contain ``scripts/ijt_live_readiness.py``
+# at all, so this exclusion is a no-op there.
+_VENDORED_PATHS: tuple[Path, ...] = (_PROJECT_ROOT / "scripts" / "ijt_live_readiness.py",)
+
 
 def _all_py_files(root: Path) -> list[Path]:
-    """All .py files in the project, excluding generated/dependency dirs."""
+    """All .py files in the project, excluding generated/dependency dirs and
+    files vendored from outside the Web Client tree."""
 
     def _skip(part: str) -> bool:
         return part in _SKIP_DIRS or part.startswith(".venv") or part.startswith("venv")
 
-    return [f for f in root.rglob("*.py") if not any(_skip(part) for part in f.parts)]
+    return [f for f in root.rglob("*.py") if not any(_skip(part) for part in f.parts) and f not in _VENDORED_PATHS]
 
 
 def _tool_available(name: str) -> bool:

--- a/OPC_UA_Servers/Release2/run_all_tests.py
+++ b/OPC_UA_Servers/Release2/run_all_tests.py
@@ -47,7 +47,6 @@ import datetime
 import json
 import os
 import shutil
-import socket
 import subprocess
 import sys
 import time
@@ -71,6 +70,15 @@ _PYTHON_CONSTRAINTS = _REPO_ROOT / "constraints.txt"
 _BANDIT_CONFIG = _REPO_ROOT / "pyproject.toml"
 RESULTS_DIR = PROJ_DIR / "test-results"
 
+# Shared readiness module: used here for compose-log capture on failure and
+# for the stdlib-only OPC UA HELLO readiness probe.
+# The module's top-level imports are stdlib-only by contract, so importing it
+# from the Phase-1 / Phase-2 runner does NOT add any third-party dependency.
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if _SCRIPTS_DIR.is_dir() and str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from ijt_live_readiness import wait_for_opcua_hello as _shared_wait_for_opcua_hello  # noqa: E402
+
 _IS_WINDOWS = sys.platform == "win32"
 
 _LINUX_BINARY = PROJ_DIR / "OPC_UA_IJT_Server_Simulator_Linux" / "opcua_ijt_demo_application"
@@ -78,6 +86,29 @@ _LINUX_ZIP = PROJ_DIR / "OPC_UA_IJT_Server_Simulator_Linux.zip"
 _WINDOWS_ZIP = PROJ_DIR / "OPC_UA_IJT_Server_Simulator.zip"
 
 _DEFAULT_PORT = 40451
+
+
+def _capture_server_compose_failure_logs(label: str) -> None:
+    """Best-effort capture of compose logs into ``test-results/readiness/``.
+
+    Uses the shared :func:`ijt_live_readiness.capture_compose_logs_on_failure`
+    helper so the failure-diagnostic format matches the rest of the IJT
+    readiness contract (no per-caller log-tail re-implementations).
+    """
+    try:
+        from ijt_live_readiness import (  # noqa: PLC0415 — deferred import
+            capture_compose_logs_on_failure,
+        )
+    except ImportError:  # pragma: no cover — defensive only
+        return
+    diag_dir = RESULTS_DIR / "readiness"
+    capture_compose_logs_on_failure(
+        diag_dir,
+        PROJ_DIR,
+        f"opcua-server-{label}",
+    )
+
+
 _DEFAULT_URL = f"opc.tcp://localhost:{_DEFAULT_PORT}"
 
 
@@ -955,21 +986,10 @@ def _parse_opcua_url(url: str) -> tuple[str, int]:
     return host, port
 
 
-def _is_reachable(host: str, port: int, timeout: float = 2.0) -> bool:
-    try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except OSError:
-        return False
+def _wait_for_opcua_hello(host: str, port: int, timeout: float = 60.0) -> bool:
+    """Return True only after the server answers an OPC UA Binary HELLO."""
 
-
-def _wait_for_port(host: str, port: int, timeout: float = 60.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if _is_reachable(host, port):
-            return True
-        time.sleep(1.0)
-    return False
+    return _shared_wait_for_opcua_hello(host, port, timeout=timeout).ok
 
 
 def _run_smoke_test(venv_py: Path, server_url: str) -> tuple[bool, str, int]:
@@ -1038,7 +1058,7 @@ def run_phase2(results: list) -> None:
         _record(results, 2, "OPC UA Smoke", False, f"FAIL (bad URL: {exc})")
         return
 
-    already_up = _is_reachable(host, port)
+    already_up = _wait_for_opcua_hello(host, port, timeout=3.0)
     launched_proc = None
     launched_docker = False
 
@@ -1076,15 +1096,42 @@ def run_phase2(results: list) -> None:
                     return
 
             elif _is_docker_running() and (PROJ_DIR / "docker-compose.yml").exists():
-                _print("  Launching via: docker compose up -d --build ...")
-                r = subprocess.run(
-                    ["docker", "compose", "up", "-d", "--build"],
-                    check=False,
-                    cwd=str(PROJ_DIR),
-                    capture_output=True,
-                    text=True,
-                )
+                _print("  Launching via: docker compose up -d --build --wait ...")
+                # --wait-timeout 300s covers cold-build + start_period 20s +
+                # interval 10s × retries 6 healthcheck budget with margin.
+                # Outer subprocess.run timeout adds 60s slack for the docker
+                # CLI / daemon / image pull itself (--wait-timeout only bounds
+                # the healthcheck poll, not docker build or registry I/O).
+                try:
+                    r = subprocess.run(
+                        [
+                            "docker",
+                            "compose",
+                            "up",
+                            "-d",
+                            "--build",
+                            "--wait",
+                            "--wait-timeout",
+                            "300",
+                        ],
+                        check=False,
+                        cwd=str(PROJ_DIR),
+                        capture_output=True,
+                        text=True,
+                        timeout=300 + 60,
+                    )
+                except subprocess.TimeoutExpired as exc:
+                    _capture_server_compose_failure_logs("server-compose-up-timeout")
+                    _record(
+                        results,
+                        2,
+                        "OPC UA Smoke",
+                        False,
+                        f"FAIL (docker compose up outer timeout after {exc.timeout:.0f}s)",
+                    )
+                    return
                 if r.returncode != 0:
+                    _capture_server_compose_failure_logs("server-compose-up-failed")
                     _record(
                         results,
                         2,
@@ -1104,17 +1151,19 @@ def run_phase2(results: list) -> None:
                 _record(results, 2, "OPC UA Smoke", True, "SKIP (no server available)")
                 return
 
-        # Wait for the port to open after launch
+        # Wait for protocol readiness after launch. TCP-open alone is not
+        # sufficient: the simulator can bind its socket before the OPC UA stack
+        # is ready to answer a binary HELLO.
         if launched_proc is not None or launched_docker:
-            _print(f"  Waiting for OPC UA port {port} ...")
+            _print(f"  Waiting for OPC UA HELLO on port {port} ...")
             t_launch = time.monotonic()
-            if not _wait_for_port(host, port, timeout=60.0):
+            if not _wait_for_opcua_hello(host, port, timeout=60.0):
                 _record(
                     results,
                     2,
                     "OPC UA Smoke",
                     False,
-                    f"FAIL (server did not open port {port} within 60 s)",
+                    f"FAIL (server did not answer OPC UA HELLO on port {port} within 60 s)",
                 )
                 return
             response_time = time.monotonic() - t_launch

--- a/scripts/ijt_live_readiness.py
+++ b/scripts/ijt_live_readiness.py
@@ -1,0 +1,713 @@
+"""
+Shared live-test readiness contract for the IJT repository.
+
+Architectural principle (carried forward from the Browser CI synchronization
+commit):
+
+    No external waits. No inferred identity. No timeout-as-sync.
+    Producer and consumer share a dependency edge with a passed-forward output.
+
+For live tests, the analogous contract is:
+
+    Wait by protocol handshake, not by TCP port liveness.
+    Capture deterministic diagnostics into a job-scoped directory whenever a
+    wait fails. Use compose-native --wait/healthcheck synchronization when
+    docker compose is the producer; otherwise issue a real protocol probe.
+
+Two import tiers:
+
+1. Mandatory (stdlib-only). The functions ``wait_for_tcp``,
+   ``wait_for_opcua_hello``, ``write_diagnostic_manifest``,
+   ``capture_compose_logs_on_failure``, and ``capture_process_log_tail`` import
+   nothing outside the Python standard library at module-import time. This
+   tier MUST stay importable from ``scripts/start_server_on_port.py``, which
+   runs in CI jobs (notably C# Live) before any ``pip install`` step.
+
+2. Optional (``asyncua`` / ``websockets``). The functions
+   ``wait_for_opcua_session`` and ``wait_for_websocket_backend`` perform
+   *deferred* third-party imports inside their function bodies. Importing
+   ``ijt_live_readiness`` itself stays dependency-light; only callers that
+   actually invoke these functions need the optional dependencies installed.
+
+Diagnostic contract:
+
+    Every public ``wait_for_*`` function returns a :class:`ReadinessResult`.
+    Callers that pass ``diagnostics_dir=<path>`` get a JSON manifest written
+    to ``<path>/readiness-diagnostic-<caller>.json`` regardless of outcome,
+    plus compose-log / process-log tails on failure when applicable.
+
+This module is the single source of truth for what "ready" means across the
+C# fixture, Python live conftests, runner scripts, and the CI workflows that
+invoke ``start_server_on_port.py``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import json
+import os
+import socket
+import subprocess
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "COMPOSE_WAIT_TIMEOUT_WARM_SECONDS",
+    "COMPOSE_WAIT_TIMEOUT_COLD_SECONDS",
+    "OPCUA_HELLO_DEFAULT_TIMEOUT_SECONDS",
+    "ReadinessResult",
+    "capture_compose_logs_on_failure",
+    "capture_process_log_tail",
+    "wait_for_opcua_hello",
+    "wait_for_opcua_session",
+    "wait_for_tcp",
+    "wait_for_websocket_backend",
+    "write_diagnostic_manifest",
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Named timeout budgets
+#
+# Server compose healthcheck (OPC_UA_Servers/Release2/docker-compose.yml):
+#   start_period 20s + interval 10s × retries 6 ≈ 80s budget.
+# Web Client compose healthcheck (IJT_Web_Client/docker-compose.yml):
+#   start_period 20s + interval 30s × retries 3 ≈ 110s budget.
+# WARM covers both with safety margin; COLD covers the additional image build.
+# These two are the only allowed values for compose ``--wait-timeout``.
+# ─────────────────────────────────────────────────────────────────────────────
+COMPOSE_WAIT_TIMEOUT_WARM_SECONDS = 120
+COMPOSE_WAIT_TIMEOUT_COLD_SECONDS = 300
+OPCUA_HELLO_DEFAULT_TIMEOUT_SECONDS = 60.0
+
+_MANIFEST_SCHEMA_VERSION = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class ReadinessResult:
+    """Outcome of one ``wait_for_*`` call.
+
+    ``ok`` is True iff the probe succeeded within budget. ``error`` is None
+    on success and a single-line summary on failure. ``elapsed_seconds`` is
+    monotonic wall-clock time spent inside the wait, not CPU time.
+    """
+
+    ok: bool
+    probe: str
+    host: str
+    port: int
+    elapsed_seconds: float
+    attempts: int
+    started_at: str
+    finished_at: str
+    error: str | None = None
+    endpoint: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 1 — stdlib-only probes
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def wait_for_tcp(
+    host: str,
+    port: int,
+    *,
+    timeout: float = OPCUA_HELLO_DEFAULT_TIMEOUT_SECONDS,
+    interval: float = 1.0,
+    connect_timeout: float = 2.0,
+) -> ReadinessResult:
+    """Wait until ``host:port`` accepts a TCP connection or timeout elapses.
+
+    This is the weakest probe. Prefer :func:`wait_for_opcua_hello` for OPC UA
+    servers and :func:`wait_for_websocket_backend` for the WS bridge — open
+    TCP does not imply protocol readiness.
+    """
+
+    started_at = _utcnow_iso()
+    start = time.monotonic()
+    deadline = start + timeout
+    attempts = 0
+    last_error: str | None = None
+    while time.monotonic() < deadline:
+        attempts += 1
+        try:
+            with socket.create_connection((host, port), timeout=connect_timeout):
+                elapsed = time.monotonic() - start
+                return ReadinessResult(
+                    ok=True,
+                    probe="tcp",
+                    host=host,
+                    port=port,
+                    elapsed_seconds=round(elapsed, 3),
+                    attempts=attempts,
+                    started_at=started_at,
+                    finished_at=_utcnow_iso(),
+                    error=None,
+                )
+        except OSError as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            time.sleep(interval)
+
+    elapsed = time.monotonic() - start
+    return ReadinessResult(
+        ok=False,
+        probe="tcp",
+        host=host,
+        port=port,
+        elapsed_seconds=round(elapsed, 3),
+        attempts=attempts,
+        started_at=started_at,
+        finished_at=_utcnow_iso(),
+        error=f"TCP {host}:{port} not accepting connections within {timeout:.1f}s "
+        f"(last error: {last_error or 'no attempts made'})",
+    )
+
+
+def _build_opcua_hello_message(host: str, port: int) -> bytes:
+    """Build the minimal well-formed OPC UA Binary HELLO message.
+
+    Layout per OPC UA Part 6 §7.1.2.3 (MessageType + Chunk + Length + Hello):
+        Bytes  0..3  : 'HEL' + 'F'
+        Bytes  4..7  : MessageSize (LE)
+        Bytes  8..11 : ProtocolVersion = 0
+        Bytes 12..15 : ReceiveBufferSize = 65536
+        Bytes 16..19 : SendBufferSize    = 65536
+        Bytes 20..23 : MaxMessageSize    = 0 (unlimited)
+        Bytes 24..27 : MaxChunkCount     = 0 (unlimited)
+        Bytes 28..31 : EndpointUrl length (LE)
+        Bytes 32..   : EndpointUrl bytes (ASCII)
+
+    Mirrors the Console live conftest probe and the C# fixture
+    ProbeOpcUaReady helper.
+    """
+
+    endpoint_url = f"opc.tcp://{host}:{port}".encode("ascii")
+    url_len = len(endpoint_url)
+    total_len = 32 + url_len
+    hello = bytearray()
+    hello += b"HELF"
+    hello += total_len.to_bytes(4, "little")
+    hello += (0).to_bytes(4, "little")
+    hello += (65536).to_bytes(4, "little")
+    hello += (65536).to_bytes(4, "little")
+    hello += (0).to_bytes(4, "little")
+    hello += (0).to_bytes(4, "little")
+    hello += url_len.to_bytes(4, "little")
+    hello += endpoint_url
+    return bytes(hello)
+
+
+def wait_for_opcua_hello(
+    host: str,
+    port: int,
+    *,
+    timeout: float = OPCUA_HELLO_DEFAULT_TIMEOUT_SECONDS,
+    interval: float = 1.0,
+    socket_timeout: float = 3.0,
+) -> ReadinessResult:
+    """Wait until the OPC UA server responds to a raw HELLO with ACK or ERR.
+
+    Either response means the OPC UA stack is alive — ACK is the happy path,
+    ERR is the server politely rejecting our minimal HELLO (still proves
+    binary-protocol readiness). Any other reply, EOF, or connection failure
+    is treated as not-yet-ready and retried until ``timeout`` elapses.
+
+    Stdlib-only by design. Safe to call from
+    ``scripts/start_server_on_port.py`` in CI jobs that have not run
+    ``pip install`` yet (notably the C# Live job).
+    """
+
+    started_at = _utcnow_iso()
+    start = time.monotonic()
+    deadline = start + timeout
+    attempts = 0
+    last_error: str | None = None
+    hello = _build_opcua_hello_message(host, port)
+
+    while time.monotonic() < deadline:
+        attempts += 1
+        try:
+            with socket.create_connection((host, port), timeout=socket_timeout) as sock:
+                sock.settimeout(socket_timeout)
+                sock.sendall(hello)
+                header = sock.recv(8)
+                if len(header) >= 4 and header[:3] in (b"ACK", b"ERR") and header[3:4] == b"F":
+                    elapsed = time.monotonic() - start
+                    return ReadinessResult(
+                        ok=True,
+                        probe="opcua_hello",
+                        host=host,
+                        port=port,
+                        elapsed_seconds=round(elapsed, 3),
+                        attempts=attempts,
+                        started_at=started_at,
+                        finished_at=_utcnow_iso(),
+                        error=None,
+                        endpoint=f"opc.tcp://{host}:{port}",
+                    )
+                last_error = f"unexpected reply: {header!r}"
+        except (TimeoutError, OSError) as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(interval)
+
+    elapsed = time.monotonic() - start
+    return ReadinessResult(
+        ok=False,
+        probe="opcua_hello",
+        host=host,
+        port=port,
+        elapsed_seconds=round(elapsed, 3),
+        attempts=attempts,
+        started_at=started_at,
+        finished_at=_utcnow_iso(),
+        error=f"OPC UA HELLO probe to {host}:{port} did not get ACK/ERR within "
+        f"{timeout:.1f}s (last error: {last_error or 'no attempts made'})",
+        endpoint=f"opc.tcp://{host}:{port}",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 2 — deferred third-party probes (asyncua, websockets)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def opcua_session_probe_once(
+    endpoint_url: str,
+    *,
+    connect_timeout: float = 5.0,
+) -> str | None:
+    """Run a single asyncua connect+disconnect against ``endpoint_url``.
+
+    Returns ``None`` on success, a single-line error string on failure. Use
+    this when the caller wants to own the retry loop (so it can interleave
+    progress logging, sleep policy, or alternative probes). Higher-level
+    callers should prefer :func:`wait_for_opcua_session`.
+    """
+
+    try:
+        import asyncio
+
+        from asyncua import Client as _AsyncuaClient
+    except ImportError as exc:  # pragma: no cover — environment-specific
+        return f"ImportError: asyncua not installed: {exc}"
+
+    async def _probe_once() -> None:
+        # asyncua's Client is positional ``(url, timeout)``; using kwargs here
+        # breaks call-site fakes that pin the constructor shape.
+        client = _AsyncuaClient(endpoint_url, connect_timeout)
+        try:
+            await client.connect()
+        finally:
+            # asyncua's connect() raises before any state is set when the
+            # server is not yet listening; disconnect() then is a no-op
+            # except for resource cleanup, hence the broad suppression.
+            with contextlib.suppress(Exception):
+                await client.disconnect()
+
+    try:
+        asyncio.run(_probe_once())
+    except Exception as exc:  # noqa: BLE001 — asyncua raises many shapes
+        return f"{type(exc).__name__}: {exc}"
+    return None
+
+
+def wait_for_opcua_session(
+    endpoint_url: str,
+    *,
+    timeout: float = OPCUA_HELLO_DEFAULT_TIMEOUT_SECONDS,
+    interval: float = 2.0,
+    connect_timeout: float = 5.0,
+) -> ReadinessResult:
+    """Wait until an asyncua client can connect+disconnect from ``endpoint_url``.
+
+    Stronger than :func:`wait_for_opcua_hello` because it negotiates a real
+    secure channel and session. Use this from Python clients that already
+    depend on ``asyncua`` (Web Client, Test Client). Do not call from
+    ``start_server_on_port.py`` — that script runs without ``asyncua``.
+    """
+
+    host, port = _parse_opcua_endpoint(endpoint_url)
+    started_at = _utcnow_iso()
+    start = time.monotonic()
+    deadline = start + timeout
+    attempts = 0
+    last_error: str | None = None
+
+    while time.monotonic() < deadline:
+        attempts += 1
+        last_error = opcua_session_probe_once(endpoint_url, connect_timeout=connect_timeout)
+        if last_error is None:
+            elapsed = time.monotonic() - start
+            return ReadinessResult(
+                ok=True,
+                probe="opcua_session",
+                host=host,
+                port=port,
+                elapsed_seconds=round(elapsed, 3),
+                attempts=attempts,
+                started_at=started_at,
+                finished_at=_utcnow_iso(),
+                error=None,
+                endpoint=endpoint_url,
+            )
+        time.sleep(interval)
+
+    elapsed = time.monotonic() - start
+    return ReadinessResult(
+        ok=False,
+        probe="opcua_session",
+        host=host,
+        port=port,
+        elapsed_seconds=round(elapsed, 3),
+        attempts=attempts,
+        started_at=started_at,
+        finished_at=_utcnow_iso(),
+        error=f"asyncua session probe to {endpoint_url} did not succeed within "
+        f"{timeout:.1f}s (last error: {last_error or 'no attempts made'})",
+        endpoint=endpoint_url,
+    )
+
+
+def websocket_probe_once(
+    probe_url: str,
+    *,
+    payload_json: str,
+    handshake_id: str,
+    open_timeout: float = 5.0,
+    close_timeout: float = 2.0,
+    response_timeout: float = 5.0,
+    max_response_frames: int = 5,
+) -> str | None:
+    """Run a single WebSocket open → send(payload) → recv(handshake reply) round.
+
+    Returns ``None`` on success, an error string on failure. ``response_timeout``
+    is an *absolute* budget: the total time spent in recv() loops will never
+    exceed it, regardless of how many frames the backend sends. The caller
+    owns retries (sleep/jitter) so it can apply call-site-specific policy.
+
+    The probe succeeds as soon as it receives any frame whose JSON text
+    contains ``handshake_id``. The backend may answer with a normal payload
+    or with ``{"exception": "..."}``; both are treated as success because the
+    contract being tested is "WebSocket plumbing works", not "this particular
+    backend command succeeded".
+    """
+
+    try:
+        import asyncio
+
+        import websockets
+    except ImportError as exc:  # pragma: no cover — environment-specific
+        return f"ImportError: websockets not installed: {exc}"
+
+    def _reply_matches_handshake(reply: object) -> bool:
+        """Return True iff ``reply`` carries an exact ``uniqueid == handshake_id``.
+
+        The reply must be a JSON object whose ``uniqueid`` field equals the
+        expected handshake id. Substring containment is intentionally NOT
+        accepted: an attacker (or a buggy backend) returning
+        ``"not-<handshake_id>"`` MUST be rejected, otherwise the probe would
+        treat the wrong session as success.
+        """
+
+        text = reply if isinstance(reply, str) else str(reply)
+        try:
+            obj = json.loads(text)
+        except (TypeError, ValueError):
+            return False
+        if not isinstance(obj, dict):
+            return False
+        return obj.get("uniqueid") == handshake_id
+
+    async def _probe_once() -> None:
+        async with websockets.connect(
+            probe_url,
+            open_timeout=open_timeout,
+            close_timeout=close_timeout,
+        ) as ws:
+            await ws.send(payload_json)
+            recv_deadline = time.monotonic() + response_timeout
+            last_reply: object | None = None
+            for _ in range(max_response_frames):
+                remaining = recv_deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"no handshake-correlated frame within {response_timeout:.1f}s budget"
+                    )
+                reply = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                last_reply = reply
+                if _reply_matches_handshake(reply):
+                    return
+            raise RuntimeError(
+                f"no reply with uniqueid=={handshake_id!r} "
+                f"after {max_response_frames} frames; last={last_reply!r}"
+            )
+
+    try:
+        asyncio.run(_probe_once())
+    except Exception as exc:  # noqa: BLE001 — websockets/asyncio raise many shapes
+        return f"{type(exc).__name__}: {exc}"
+    return None
+
+
+def wait_for_websocket_backend(
+    probe_url: str,
+    *,
+    payload_json: str,
+    handshake_id: str,
+    timeout: float = 30.0,
+    interval: float = 1.0,
+    open_timeout: float = 5.0,
+    close_timeout: float = 2.0,
+    response_timeout: float = 5.0,
+) -> ReadinessResult:
+    """Retry :func:`websocket_probe_once` until success or ``timeout`` elapses.
+
+    The caller supplies the JSON ``payload_json`` to send and the
+    ``handshake_id`` to look for in the reply. This keeps the IJT-specific
+    handshake shape (which command, which endpoint name, which uniqueid) out
+    of the shared module — see the Web Client adapter for the actual contract.
+    """
+
+    host, port = _parse_ws_endpoint(probe_url)
+    started_at = _utcnow_iso()
+    start = time.monotonic()
+    deadline = start + timeout
+    attempts = 0
+    last_error: str | None = None
+
+    while time.monotonic() < deadline:
+        attempts += 1
+        last_error = websocket_probe_once(
+            probe_url,
+            payload_json=payload_json,
+            handshake_id=handshake_id,
+            open_timeout=open_timeout,
+            close_timeout=close_timeout,
+            response_timeout=response_timeout,
+        )
+        if last_error is None:
+            elapsed = time.monotonic() - start
+            return ReadinessResult(
+                ok=True,
+                probe="websocket_backend",
+                host=host,
+                port=port,
+                elapsed_seconds=round(elapsed, 3),
+                attempts=attempts,
+                started_at=started_at,
+                finished_at=_utcnow_iso(),
+                error=None,
+                endpoint=probe_url,
+            )
+        time.sleep(interval)
+
+    elapsed = time.monotonic() - start
+    return ReadinessResult(
+        ok=False,
+        probe="websocket_backend",
+        host=host,
+        port=port,
+        elapsed_seconds=round(elapsed, 3),
+        attempts=attempts,
+        started_at=started_at,
+        finished_at=_utcnow_iso(),
+        error=f"WebSocket backend at {probe_url} did not complete handshake "
+        f"{handshake_id!r} within {timeout:.1f}s "
+        f"(last error: {last_error or 'no attempts made'})",
+        endpoint=probe_url,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint parsing helpers (stdlib-only)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_opcua_endpoint(endpoint_url: str) -> tuple[str, int]:
+    """Parse ``opc.tcp://host:port[/...]`` → (host, port)."""
+
+    if not endpoint_url.startswith("opc.tcp://"):
+        raise ValueError(f"Not an opc.tcp:// URL: {endpoint_url!r}")
+    rest = endpoint_url[len("opc.tcp://") :]
+    authority = rest.split("/", 1)[0]
+    if ":" not in authority:
+        raise ValueError(f"opc.tcp URL missing :port — {endpoint_url!r}")
+    host, port_str = authority.rsplit(":", 1)
+    return host, int(port_str)
+
+
+def _parse_ws_endpoint(probe_url: str) -> tuple[str, int]:
+    """Parse ``ws://host:port[/...]`` or ``wss://host:port[/...]`` → (host, port)."""
+
+    for scheme in ("ws://", "wss://"):
+        if probe_url.startswith(scheme):
+            rest = probe_url[len(scheme) :]
+            authority = rest.split("/", 1)[0]
+            if ":" not in authority:
+                # Default ws=80, wss=443; the IJT backend always specifies a port.
+                raise ValueError(f"ws URL missing :port — {probe_url!r}")
+            host, port_str = authority.rsplit(":", 1)
+            return host, int(port_str)
+    raise ValueError(f"Not a ws:// or wss:// URL: {probe_url!r}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Diagnostic capture (stdlib-only)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _slugify(caller: str) -> str:
+    return (
+        "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in caller).strip("_") or "caller"
+    )
+
+
+def write_diagnostic_manifest(
+    directory: Path | str | None,
+    result: ReadinessResult,
+    *,
+    caller: str,
+    extra: dict[str, Any] | None = None,
+) -> Path | None:
+    """Write a JSON manifest summarising one readiness wait into ``directory``.
+
+    Returns the manifest path on success, ``None`` when ``directory`` is None
+    or empty. Always safe — never raises through caller stacks (best-effort
+    write; logs to stderr on failure but does not re-raise).
+    """
+
+    if not directory:
+        return None
+    target = Path(directory)
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+        path = target / f"readiness-diagnostic-{_slugify(caller)}.json"
+        payload: dict[str, Any] = {
+            "schema_version": _MANIFEST_SCHEMA_VERSION,
+            "caller": caller,
+            "result": result.to_dict(),
+        }
+        if extra:
+            payload["extra"] = extra
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return path
+    except OSError as exc:
+        # Best-effort: a diagnostics-write failure must not mask the real test
+        # outcome. Print and move on.
+        import sys
+
+        print(
+            f"[ijt_live_readiness] WARN: could not write diagnostic manifest to {target!r}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def capture_compose_logs_on_failure(
+    directory: Path | str | None,
+    compose_dir: Path | str,
+    service: str,
+    *,
+    project: str | None = None,
+    docker_executable: str = "docker",
+    tail: int = 200,
+) -> Path | None:
+    """Save ``docker compose logs --no-color --tail=<N> <service>`` into ``directory``.
+
+    Intended to be called from the failure branch of a readiness wait, after
+    the manifest is written. Best-effort: returns ``None`` when ``directory``
+    is empty or the docker invocation fails.
+    """
+
+    if not directory:
+        return None
+    target = Path(directory)
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    env = os.environ.copy()
+    if project:
+        env["COMPOSE_PROJECT_NAME"] = project
+
+    args = [
+        docker_executable,
+        "compose",
+        "logs",
+        "--no-color",
+        "--tail",
+        str(int(tail)),
+        service,
+    ]
+    try:
+        completed = subprocess.run(  # noqa: S603 — explicit argv, env-scoped
+            args,
+            cwd=str(compose_dir),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        path = target / f"compose-logs-{_slugify(service)}.txt"
+        path.write_text(
+            f"[ijt_live_readiness] failed to capture compose logs: {exc}\n",
+            encoding="utf-8",
+        )
+        return path
+
+    path = target / f"compose-logs-{_slugify(service)}.txt"
+    body = (
+        f"# docker compose logs --no-color --tail={tail} {service}\n"
+        f"# cwd: {compose_dir}\n"
+        f"# exit_code: {completed.returncode}\n"
+        f"# captured_at: {_utcnow_iso()}\n"
+        f"\n--- stdout ---\n{completed.stdout}\n--- stderr ---\n{completed.stderr}\n"
+    )
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def capture_process_log_tail(
+    directory: Path | str | None,
+    name: str,
+    lines: list[str],
+    *,
+    tail: int = 200,
+) -> Path | None:
+    """Write the last ``tail`` lines of an in-memory log buffer to ``directory``.
+
+    Useful for callers (notably ``start_server_on_port.py``) that capture a
+    subprocess's stdout/stderr into a rolling buffer instead of streaming to
+    DEVNULL. Best-effort, never raises through the caller stack.
+    """
+
+    if not directory or not lines:
+        return None
+    target = Path(directory)
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    snippet = lines[-int(tail) :] if len(lines) > tail else list(lines)
+    path = target / f"process-log-{_slugify(name)}.txt"
+    body = (
+        f"# process log tail (last {len(snippet)} of {len(lines)} captured lines)\n"
+        f"# name: {name}\n"
+        f"# captured_at: {_utcnow_iso()}\n\n" + "\n".join(snippet) + "\n"
+    )
+    path.write_text(body, encoding="utf-8")
+    return path

--- a/scripts/start_server_on_port.py
+++ b/scripts/start_server_on_port.py
@@ -11,9 +11,15 @@ Start mode (default)
     2. Patches ``serverEndpointTCPPort`` in the copy's
        ``server_configuration.json``
     3. Starts the executable from the copied directory
-    4. Waits up to ``--timeout`` seconds for the port to open
+    4. Waits up to ``--timeout`` seconds for the OPC UA HELLO handshake to
+       succeed on the patched port (via the shared
+       :func:`ijt_live_readiness.wait_for_opcua_hello` probe — TCP-port
+       liveness alone is NOT sufficient)
     5. Exports ``SERVER_PID``, ``OPCUA_SERVER_PORT``, and
        ``OPCUA_SERVER_URL`` to ``GITHUB_ENV`` (no-op outside CI)
+    6. On readiness failure, writes a JSON manifest plus the last lines of
+       the simulator's stdout/stderr to ``--diagnostics-dir`` (when set) so
+       the calling CI job's upload-artifact step can attach them.
 
 Stop mode (``--stop``)
     Reads ``SERVER_PID`` from the environment to terminate the server process.
@@ -27,7 +33,8 @@ Examples (CI YAML)::
 
     - name: Start OPC UA server on port 40464
       working-directory: ${{ github.workspace }}
-      run: python scripts/start_server_on_port.py --port 40464
+      run: python scripts/start_server_on_port.py --port 40464 \\
+             --diagnostics-dir test-results/readiness
 
     - name: Stop OPC UA server
       if: always()
@@ -41,19 +48,36 @@ Examples (local dev, from repo root)::
 """
 
 import argparse
+import contextlib
 import json
 import os
 import shutil
 import signal
-import socket
 import subprocess
 import sys
 import tempfile
-import time
+import threading
 from pathlib import Path
+
+# The shared readiness module is a sibling file. Adding the script's directory
+# to sys.path is automatic when this file is invoked as ``python scripts/...``;
+# the explicit insert here keeps both ``python -m`` and direct invocation
+# working from any cwd.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+# Stdlib-only sibling: this import MUST NOT pull in any third-party package
+# because this script runs in CI before ``pip install`` (notably C# Live).
+from ijt_live_readiness import (  # noqa: E402
+    capture_process_log_tail,
+    wait_for_opcua_hello,
+    write_diagnostic_manifest,
+)
 
 DEFAULT_SERVER_DIR = Path("OPC_UA_Servers/Release2/OPC_UA_IJT_Server_Simulator")
 DEFAULT_TIMEOUT = 60
+_PROCESS_LOG_BUFFER_LIMIT = 400
 
 
 def _write_github_env(key: str, value: str) -> None:
@@ -63,17 +87,31 @@ def _write_github_env(key: str, value: str) -> None:
             f.write(f"{key}={value}\n")
 
 
-def _wait_for_port(port: int, timeout: int) -> float:
-    """Return seconds elapsed, or -1 on timeout."""
-    start = time.monotonic()
-    deadline = start + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("localhost", port), timeout=2):
-                return time.monotonic() - start
-        except OSError:
-            time.sleep(2)
-    return -1.0
+def _spawn_log_pump(stream, buffer: list[str], stream_name: str) -> threading.Thread:
+    """Drain ``stream`` line-by-line into ``buffer`` (rolling) on a daemon thread.
+
+    Replaces the previous ``stdout=DEVNULL`` so that, on a readiness failure,
+    we can dump the simulator's last few lines into the job-scoped diagnostics
+    directory. The buffer is bounded; old lines are dropped.
+    """
+
+    def _pump() -> None:
+        with contextlib.suppress(Exception):
+            try:
+                for raw in iter(stream.readline, b""):
+                    if not raw:
+                        break
+                    line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
+                    buffer.append(f"{stream_name}: {line}")
+                    if len(buffer) > _PROCESS_LOG_BUFFER_LIMIT:
+                        del buffer[: len(buffer) - _PROCESS_LOG_BUFFER_LIMIT]
+            finally:
+                with contextlib.suppress(Exception):
+                    stream.close()
+
+    thread = threading.Thread(target=_pump, name=f"ijt-sim-{stream_name}", daemon=True)
+    thread.start()
+    return thread
 
 
 def _default_tmp_base() -> Path:
@@ -82,7 +120,13 @@ def _default_tmp_base() -> Path:
     return Path(base) / "ijt-sim"
 
 
-def start_server(port: int, server_dir: Path, tmp_base: Path, timeout: int) -> None:
+def start_server(
+    port: int,
+    server_dir: Path,
+    tmp_base: Path,
+    timeout: int,
+    diagnostics_dir: Path | None = None,
+) -> None:
     dst_dir = tmp_base / f"server_{port}"
     cfg_name = "server_configuration.json"
 
@@ -125,21 +169,45 @@ def start_server(port: int, server_dir: Path, tmp_base: Path, timeout: int) -> N
     proc = subprocess.Popen(  # noqa: S603
         [str(exe_path)],
         cwd=str(dst_dir),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     print(f"    Server started (PID {proc.pid})")
 
-    elapsed = _wait_for_port(port, timeout)
-    if elapsed < 0:
+    # Drain stdout/stderr into a rolling buffer so we can emit a tail on
+    # failure. Without this, simulator startup output is silently lost and
+    # CI diagnostics show only "port did not open".
+    log_buffer: list[str] = []
+    _spawn_log_pump(proc.stdout, log_buffer, "stdout")
+    _spawn_log_pump(proc.stderr, log_buffer, "stderr")
+
+    # Protocol-level readiness wait. We do not gate on raw TCP-port open
+    # because the OPC UA stack may be initialising after the port becomes
+    # reachable. wait_for_opcua_hello returns success only when the server
+    # replies to a binary HELLO with ACK or ERR, either of which proves the
+    # OPC UA stack is alive.
+    result = wait_for_opcua_hello("localhost", port, timeout=float(timeout))
+    write_diagnostic_manifest(
+        diagnostics_dir,
+        result,
+        caller=f"start_server_on_port-{port}",
+        extra={"server_dir": str(dst_dir), "exe": exe_path.name, "pid": proc.pid},
+    )
+    if not result.ok:
+        capture_process_log_tail(
+            diagnostics_dir,
+            name=f"opcua-server-{port}",
+            lines=log_buffer,
+        )
         print(
-            f"ERROR: OPC UA server did not open port {port} within {timeout}s.",
+            f"ERROR: OPC UA server did not respond to HELLO on port {port} "
+            f"within {timeout}s ({result.error}).",
             file=sys.stderr,
         )
         proc.kill()
         sys.exit(1)
 
-    print(f"    Port {port} open after {elapsed:.1f}s — server ready.")
+    print(f"    Port {port} ready after {result.elapsed_seconds:.1f}s — server ready.")
 
     _write_github_env("SERVER_PID", str(proc.pid))
     _write_github_env("OPCUA_SERVER_PORT", str(port))
@@ -211,7 +279,19 @@ def main() -> None:
         "--timeout",
         type=int,
         default=DEFAULT_TIMEOUT,
-        help=f"Seconds to wait for port to open (default: {DEFAULT_TIMEOUT})",
+        help=f"Seconds to wait for OPC UA HELLO/ACK (default: {DEFAULT_TIMEOUT})",
+    )
+    parser.add_argument(
+        "--diagnostics-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help=(
+            "Directory to write the readiness diagnostic manifest "
+            "(readiness-diagnostic-start_server_on_port-<port>.json) and, on "
+            "failure, the simulator stdout/stderr tail. The directory is "
+            "created if it does not exist."
+        ),
     )
 
     args = parser.parse_args()
@@ -223,7 +303,13 @@ def main() -> None:
     if args.stop:
         stop_server(args.port, args.tmp_base or _default_tmp_base())
     else:
-        start_server(args.port, args.server_dir, args.tmp_base or _default_tmp_base(), args.timeout)
+        start_server(
+            args.port,
+            args.server_dir,
+            args.tmp_base or _default_tmp_base(),
+            args.timeout,
+            diagnostics_dir=args.diagnostics_dir,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_synchronization_invariants.py
+++ b/tests/test_ci_synchronization_invariants.py
@@ -1,4 +1,4 @@
-"""CI synchronization invariants for the Browser CI image path.
+"""Browser CI image synchronization contract checks.
 
 These tests guard the architectural contract that fixed the producer/consumer
 race documented in run 26257538245 (PR #394). The principle:
@@ -8,8 +8,8 @@ race documented in run 26257538245 (PR #394). The principle:
     output. Cache identity is `inputs_fingerprint`. Runtime identity is
     `digest`. `GITHUB_SHA` is provenance, never validation.
 
-If any of these invariants regress, the fix is structural, not a snapshot
-update. Read the comments before relaxing an assertion.
+If any of these checks regress, the fix is structural, not a snapshot update.
+Read the comments before relaxing an assertion.
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ def _load(path: Path) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Invariant 1: no workflow step couples `docker pull` to a long polling loop.
+# No workflow step may couple `docker pull` to a long polling loop.
 # ---------------------------------------------------------------------------
 # The historical failure was a `docker pull "$tag"` inside a `for attempt in
 # $(seq 1 30); do ... sleep 20; done` budget (10 minutes) used as the
@@ -86,7 +86,7 @@ def test_no_docker_pull_polling_loop_with_long_budget(workflow_path: Path) -> No
 
 
 # ---------------------------------------------------------------------------
-# Invariant 2: live-webclient-browser reaches resolve-browser-image via needs:
+# live-webclient-browser must reach resolve-browser-image via needs.
 # ---------------------------------------------------------------------------
 # The Browser matrix must depend on the resolver job. If someone reintroduces
 # a parallel matrix that resolves identity inside its own steps, the race
@@ -106,13 +106,13 @@ def test_live_webclient_browser_needs_resolve_browser_image() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Invariant 3: IJT_BROWSER_CI_IMAGE comes from a job-output expression.
+# IJT_BROWSER_CI_IMAGE must come from a job-output expression.
 # ---------------------------------------------------------------------------
 # Steps that run the browser image must source the image reference from
 # `${{ needs.resolve-browser-image.outputs.image_ref }}`, never from a
 # step-output written by an in-job `docker pull`. The historical resolver
 # wrote `image_ref` into a step output AFTER polling for a tag — that is
-# precisely the inferred-identity pattern this commit eliminates.
+# precisely the inferred-identity pattern this contract forbids.
 
 _JOB_OUTPUT_REF = re.compile(r"\$\{\{\s*needs\.resolve-browser-image\.outputs\.image_ref\s*\}\}")
 _STEP_OUTPUT_REF = re.compile(r"\$\{\{\s*steps\.[A-Za-z0-9_]+\.outputs\.image_ref\s*\}\}")
@@ -141,7 +141,7 @@ def test_browser_matrix_image_ref_comes_from_job_output_not_step_output() -> Non
 
 
 # ---------------------------------------------------------------------------
-# Invariant 4: cache identity is fingerprint; runtime identity is digest.
+# Cache identity is the fingerprint; runtime identity is the digest.
 # ---------------------------------------------------------------------------
 # The resolver's metadata-check step must compare image.inputs_fingerprint
 # against the planner's CURRENT_FINGERPRINT. It must NOT require build_sha
@@ -180,7 +180,7 @@ def test_resolve_step_uses_fingerprint_equality_not_build_sha() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Invariant 5: producer exposes workflow_call with the planner's contract.
+# The producer exposes workflow_call with the planner's contract.
 # ---------------------------------------------------------------------------
 # The producer's PR-time entry point is workflow_call from integration.yml.
 # It must accept an `expected_fingerprint` input and emit `digest`,
@@ -207,7 +207,7 @@ def test_producer_exposes_workflow_call_with_fingerprint_contract() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Invariant 6: producer publishes a fingerprint-keyed cache tag.
+# The producer publishes a fingerprint-keyed cache tag.
 # ---------------------------------------------------------------------------
 # Repeated Renovate-style PRs with identical Browser CI image inputs must be
 # able to short-circuit at the planner via a GHCR tag lookup. That requires
@@ -245,20 +245,19 @@ def test_planner_decision_table_emits_three_plans() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Invariant 7: planner discriminates pin / cached / build deterministically
-# (handled above by test_planner_decision_table_emits_three_plans).
+# The planner must discriminate pin / cached / build deterministically.
 # ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
-# Invariant 8: reusable workflow call must NOT use `secrets: inherit`.
+# The reusable workflow call must not use `secrets: inherit`.
 # ---------------------------------------------------------------------------
 # The reusable build-browser-ci-image workflow only needs the auto-provided
 # GITHUB_TOKEN for GHCR login (available without inheritance) plus the
 # packages: write capability granted via job permissions. `secrets: inherit`
 # would broaden the secret surface to every caller secret unnecessarily —
-# zizmor flags it as `secrets-inherit` and Codex blocked Commit A on this
-# during read-only review.
+# zizmor flags it as `secrets-inherit`, and the least-privilege contract keeps
+# the call site from inheriting unrelated caller secrets.
 
 
 def test_build_browser_image_call_does_not_inherit_all_secrets() -> None:
@@ -273,7 +272,7 @@ def test_build_browser_image_call_does_not_inherit_all_secrets() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Invariant 9: live-webclient-browser overrides the default success() check.
+# live-webclient-browser must override GitHub's default success() check.
 # ---------------------------------------------------------------------------
 # resolve-browser-image uses `if: always() && ...` so it runs even when
 # build-browser-image is skipped (the common pin/cache path). GitHub's

--- a/tests/test_image_pin.py
+++ b/tests/test_image_pin.py
@@ -568,17 +568,20 @@ def test_build_browser_ci_image_workflow_keeps_pin_updates_manual_without_loop()
     assert "IMAGE_INPUTS_FINGERPRINT=${{ steps.fingerprint.outputs.inputs_fingerprint }}" in str(
         build_job
     )
-    phase0_metadata_step = next(
+    image_smoke_metadata_step = next(
         step
         for step in build_job["steps"]
-        if step.get("name") == "Phase 0 smoke - metadata + tool versions"
+        if step.get("name") == "Image smoke - metadata and tool versions"
     )
     assert (
-        phase0_metadata_step["env"]["EXPECTED_FINGERPRINT"]
+        image_smoke_metadata_step["env"]["EXPECTED_FINGERPRINT"]
         == "${{ steps.fingerprint.outputs.inputs_fingerprint }}"
     )
-    assert '"$EXPECTED_FINGERPRINT"' in phase0_metadata_step["run"]
-    assert "${{ steps.fingerprint.outputs.inputs_fingerprint }}" not in phase0_metadata_step["run"]
+    assert '"$EXPECTED_FINGERPRINT"' in image_smoke_metadata_step["run"]
+    assert (
+        "${{ steps.fingerprint.outputs.inputs_fingerprint }}"
+        not in image_smoke_metadata_step["run"]
+    )
     summary_step = next(step for step in build_job["steps"] if step.get("name") == "Job summary")
     assert (
         summary_step["env"]["INPUTS_FINGERPRINT"]
@@ -686,7 +689,7 @@ def test_build_browser_ci_image_workflow_keeps_pin_updates_manual_without_loop()
     assert "actual_fingerprint" in publish_verify_step["run"]
 
 
-def test_browser_ci_phase0_runtime_probe_uses_writable_home_paths() -> None:
+def test_browser_ci_image_smoke_runtime_probe_uses_writable_home_paths() -> None:
     """The non-root runtime probe must not overwrite root-owned /tmp build files."""
     import yaml
 
@@ -695,7 +698,7 @@ def test_browser_ci_phase0_runtime_probe_uses_writable_home_paths() -> None:
     probe_step = next(
         step
         for step in build_job["steps"]
-        if step.get("name") == "Phase 0 smoke - offline dependency closure probe"
+        if step.get("name") == "Image smoke - offline dependency closure probe"
     )
     body = probe_step["run"]
 

--- a/tests/test_live_readiness_invariants.py
+++ b/tests/test_live_readiness_invariants.py
@@ -1,0 +1,602 @@
+"""
+Live-test readiness contract checks.
+
+Preamble
+========
+
+    No external waits. No inferred identity. No timeout-as-sync.
+    Producer and consumer must share a dependency edge with a passed-forward
+    output. For live tests, the producer is whatever launches the OPC UA
+    server / Web Client stack (start_server_on_port.py, docker compose up,
+    native simulator EXE) and the consumer is the test process. The
+    dependency edge is either the compose healthcheck or a real binary
+    protocol probe (OPC UA HELLO/ACK or asyncua session). Plain TCP-port
+    liveness is never sufficient.
+
+Each test below protects a CI readiness rule that cannot be enforced by normal
+unit tests alone. Failures mean a live test path has drifted back toward
+unreliable startup synchronization.
+
+Status-function note
+====================
+
+Some workflow checks intentionally allow ``status() == 'success'`` checks via
+``always()`` / ``!cancelled()`` only when paired with an explicit needs-
+result assertion, matching the dependency-check pattern in
+``test_ci_synchronization_invariants.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SHARED_MODULE = SCRIPTS_DIR / "ijt_live_readiness.py"
+START_SERVER_SCRIPT = SCRIPTS_DIR / "start_server_on_port.py"
+WEB_CLIENT_DOCKERFILE = REPO_ROOT / "OPC_UA_Clients" / "Release2" / "IJT_Web_Client" / "Dockerfile"
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+WEB_CLIENT_READINESS_HELPER = (
+    REPO_ROOT
+    / "OPC_UA_Clients"
+    / "Release2"
+    / "IJT_Web_Client"
+    / "tests"
+    / "python"
+    / "_live_server_readiness.py"
+)
+
+# Every workflow that invokes scripts/start_server_on_port.py. Adding a new
+# workflow-level caller requires adding it here so diagnostics capture and
+# artifact upload stay guarded by the same test.
+START_SERVER_WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "ci.yml",
+    REPO_ROOT / ".github" / "workflows" / "integration.yml",
+)
+
+# Allowed compose --wait-timeout values, in seconds. Anything else is a
+# regression: the warm budget must cover the slowest compose healthcheck
+# (~110s for Web Client) and the cold budget must additionally cover image
+# build. Use the named constants in ``scripts/ijt_live_readiness.py``.
+ALLOWED_WAIT_TIMEOUTS = {"120", "300"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _load_workflow(path: Path) -> dict:
+    return yaml.safe_load(_read(path))
+
+
+def _iter_workflow_run_steps(workflow: dict):
+    """Yield (job_id, step_name, run_str) for every ``run:`` step."""
+
+    for job_id, job in (workflow.get("jobs") or {}).items():
+        for step in job.get("steps") or []:
+            run = step.get("run")
+            if run:
+                yield job_id, step.get("name") or step.get("id") or "<unnamed>", run
+
+
+def _extract_wait_timeouts(text: str) -> list[str]:
+    """Return every value passed to ``--wait-timeout`` in ``text`` (regex)."""
+
+    return re.findall(r"--wait-timeout\s+(?:[\"']?)(\d+)(?:[\"']?)", text)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# start_server_on_port.py must use the shared OPC UA readiness probe rather
+# than a private TCP-only wait loop.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_start_server_uses_shared_readiness_module() -> None:
+    source = _read(START_SERVER_SCRIPT)
+    tree = ast.parse(source)
+
+    imports_shared = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "ijt_live_readiness"
+        and any(alias.name == "wait_for_opcua_hello" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    assert imports_shared, (
+        "start_server_on_port.py must import wait_for_opcua_hello from "
+        "ijt_live_readiness; the script is the single CI entrypoint that "
+        "runs before pip install, so it must use the shared stdlib-only "
+        "readiness primitive instead of a private TCP loop."
+    )
+
+    # Forbid a "create_connection in a poll loop" shape from re-appearing.
+    # ``socket.create_connection`` itself is fine in stop-mode / port-cleanup
+    # helpers if needed, but not as the primary readiness wait.
+    assert "socket.create_connection" not in source, (
+        "start_server_on_port.py must not use socket.create_connection "
+        "directly — readiness MUST go through ijt_live_readiness.wait_for_* "
+        "so the OPC UA HELLO probe is the single source of truth."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The shared readiness module must be importable before client dependencies
+# are installed.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_STDLIB_ALLOWLIST = frozenset(
+    {
+        "__future__",
+        "contextlib",
+        "dataclasses",
+        "datetime",
+        "json",
+        "os",
+        "socket",
+        "subprocess",
+        "sys",
+        "time",
+        "pathlib",
+        "typing",
+    }
+)
+
+
+def test_shared_module_top_level_imports_are_stdlib_only() -> None:
+    tree = ast.parse(_read(SHARED_MODULE))
+    bad: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                if root not in _STDLIB_ALLOWLIST:
+                    bad.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                continue
+            root = node.module.split(".")[0]
+            if root not in _STDLIB_ALLOWLIST:
+                bad.append(f"from {node.module} import ...")
+
+    assert not bad, (
+        "scripts/ijt_live_readiness.py top-level imports must be stdlib-only "
+        "because start_server_on_port.py loads it in the C# Live job before "
+        "actions/setup-dotnet runs and no pip install is performed. Move "
+        "third-party imports (asyncua, websockets) inside the function "
+        "bodies that need them. Offenders: " + ", ".join(bad)
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Client-side readiness helpers must reuse the shared readiness module.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_READINESS_HELPER_FILES = (
+    WEB_CLIENT_READINESS_HELPER,
+    REPO_ROOT / "OPC_UA_Clients" / "Release2" / "IJT_Test_Client" / "helpers" / "server_manager.py",
+    REPO_ROOT
+    / "OPC_UA_Clients"
+    / "Release2"
+    / "IJT_Console_Client"
+    / "tests"
+    / "live"
+    / "conftest.py",
+)
+
+
+@pytest.mark.parametrize("path", _READINESS_HELPER_FILES, ids=lambda p: p.name)
+def test_client_helpers_delegate_to_shared_readiness(path: Path) -> None:
+    assert path.is_file(), f"Expected readiness helper at {path}"
+    source = _read(path)
+    assert "from ijt_live_readiness import" in source, (
+        f"{path.relative_to(REPO_ROOT)} must import from ijt_live_readiness so "
+        "the readiness contract is defined in exactly one place. Add the "
+        "shared module's scripts/ directory to sys.path and import the "
+        "wait_for_* primitives instead of reimplementing them locally."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Every individual ``docker compose up`` callsite must wait for compose
+# healthchecks and use a bounded outer process timeout. Pin by callsite count,
+# not by file containment: a future second compose-up in the same file must not
+# be allowed to slip in unguarded.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Number of distinct ``docker compose up`` callsites expected per tracked
+# file. The Web Client runner has two (auto-launch helper for the OPC UA
+# server + docker-smoke stage); every other file has one. Adding a callsite
+# requires bumping the count here so the architectural review is explicit.
+COMPOSE_UP_EXPECTED_CALLSITES: dict[Path, int] = {
+    REPO_ROOT / ".github" / "workflows" / "ci.yml": 1,
+    REPO_ROOT / "OPC_UA_Clients" / "Release2" / "IJT_Web_Client" / "run_all_tests.py": 2,
+    REPO_ROOT / "OPC_UA_Servers" / "Release2" / "run_all_tests.py": 1,
+    REPO_ROOT
+    / "OPC_UA_Clients"
+    / "Release2"
+    / "IJT_Console_Client"
+    / "tests"
+    / "live"
+    / "conftest.py": 1,
+    REPO_ROOT
+    / "OPC_UA_Clients"
+    / "Release2"
+    / "IJT_CSharp_Client"
+    / "Tests"
+    / "IJT_CSharp_Client.Tests"
+    / "OpcUaServerFixture.cs": 1,
+}
+
+
+_COMPOSE_UP_PATTERNS_YAML: tuple[re.Pattern[str], ...] = (
+    # Workflow YAML: shell ``docker compose up`` in a ``run:`` block.
+    re.compile(r"\bdocker\s+compose\s+up\b"),
+)
+
+_COMPOSE_UP_PATTERNS_PYTHON: tuple[re.Pattern[str], ...] = (
+    # Argv list: ``"compose", "up"`` (or ``"compose",\n    "up"``). Captures
+    # both ``["docker", "compose", "up", ...]`` (literal docker) and
+    # ``[docker_var, "compose", "up", ...]`` (variable-bound docker).
+    re.compile(r"""['"]compose['"]\s*,\s*['"]up['"]"""),
+    # Concatenated form: ``compose_cmd + ["up", ...]`` where compose_cmd is
+    # a pre-built ``[docker, "compose"]`` list. Matches any list-named
+    # variable ending in ``_cmd`` (or named ``compose_cmd``) concatenated
+    # with a literal list whose first element is ``"up"``.
+    re.compile(r"""\b\w*compose\w*_?(?:cmd|args)?\s*\+\s*\[\s*['"]up['"]"""),
+    # Builder pattern: ``compose_args.extend(["up", ...])``.
+    re.compile(r"""\bcompose_args\.extend\(\s*\[\s*['"]up['"]"""),
+)
+
+# C# fixture: anchor on ``ArgumentList.Add("up")`` because the file may
+# insert several Add() calls between ``Add("compose")`` and ``Add("up")``
+# (e.g. ``-f overrideFile``). The required ``--wait`` / ``--wait-timeout``
+# Add() calls always come after ``Add("up")``.
+_COMPOSE_UP_PATTERN_CSHARP = re.compile(r'ArgumentList\.Add\("up"\)')
+
+
+def _patterns_for(path: Path) -> tuple[re.Pattern[str], ...]:
+    suffix = path.suffix.lower()
+    if suffix in (".yml", ".yaml"):
+        return _COMPOSE_UP_PATTERNS_YAML
+    if suffix == ".py":
+        return _COMPOSE_UP_PATTERNS_PYTHON
+    if suffix == ".cs":
+        return (_COMPOSE_UP_PATTERN_CSHARP,)
+    raise AssertionError(f"No compose-up callsite patterns defined for {path.suffix} files")
+
+
+def _enumerate_compose_up_callsites(path: Path, text: str) -> list[tuple[int, str]]:
+    """Return (offset, matched_substring) for every distinct compose-up callsite.
+
+    Patterns are selected per file suffix so that shell-form strings inside
+    Python log messages (e.g. ``"docker compose up failed"``) are NOT
+    counted — only real subprocess.run argv literals are.
+    """
+
+    hits: list[tuple[int, str]] = []
+    seen_offsets: set[int] = set()
+    for pattern in _patterns_for(path):
+        for match in pattern.finditer(text):
+            offset = match.start()
+            if any(abs(offset - existing) < 80 for existing in seen_offsets):
+                continue
+            seen_offsets.add(offset)
+            hits.append((offset, match.group(0)))
+    hits.sort(key=lambda item: item[0])
+    return hits
+
+
+def _callsite_is_gated_by_wait(text: str, offset: int, window: int = 1500) -> bool:
+    """Return True iff a ``--wait`` argument appears within ``window`` chars of ``offset``."""
+    return "--wait" in text[max(0, offset - 50) : offset + window]
+
+
+# Maps named constants used in argv positions to their numeric values so
+# the invariant can validate non-literal timeouts:
+#   - C# fixture uses DockerCompose(Warm|Cold)WaitTimeoutSeconds.
+#   - Python runners use COMPOSE_WAIT_TIMEOUT_(WARM|COLD)_SECONDS imported
+#     from ijt_live_readiness.
+_NAMED_TIMEOUT_CONSTANTS = {
+    "DockerComposeWarmWaitTimeoutSeconds": "120",
+    "DockerComposeColdWaitTimeoutSeconds": "300",
+    "COMPOSE_WAIT_TIMEOUT_WARM_SECONDS": "120",
+    "COMPOSE_WAIT_TIMEOUT_COLD_SECONDS": "300",
+}
+
+
+def _callsite_wait_timeout(text: str, offset: int, window: int = 1500) -> str | None:
+    """Return the ``--wait-timeout`` value adjacent to a callsite, or None.
+
+    Accepts numeric literals (Python argv lists, YAML shell args) and the
+    named Python / C# constants documented in ``_NAMED_TIMEOUT_CONSTANTS``.
+    Returns the resolved numeric value as a string.
+    """
+    blob = text[max(0, offset - 50) : offset + window]
+    numeric = re.search(
+        r"""--wait-timeout(?:["']?(?:\s*[,=]\s*|\s+)["']?)(\d+)""",
+        blob,
+    )
+    if numeric:
+        return numeric.group(1)
+    if "--wait-timeout" in blob:
+        for name, value in _NAMED_TIMEOUT_CONSTANTS.items():
+            if name in blob:
+                return value
+    return None
+
+
+def test_every_compose_up_caller_uses_compose_wait() -> None:
+    failures: list[str] = []
+    for path, expected_count in COMPOSE_UP_EXPECTED_CALLSITES.items():
+        assert path.is_file(), f"Missing tracked compose caller: {path}"
+        text = _read(path)
+        callsites = _enumerate_compose_up_callsites(path, text)
+        rel = path.relative_to(REPO_ROOT)
+        if len(callsites) != expected_count:
+            failures.append(
+                f"{rel}: expected {expected_count} ``docker compose up`` "
+                f"callsite(s), found {len(callsites)} at offsets "
+                f"{[o for o, _ in callsites]}. Update "
+                "COMPOSE_UP_EXPECTED_CALLSITES in this test so the change is "
+                "explicit and gate every new callsite with ``--wait``."
+            )
+            continue
+        for index, (offset, snippet) in enumerate(callsites, start=1):
+            if not _callsite_is_gated_by_wait(text, offset):
+                failures.append(
+                    f"{rel} (callsite #{index} @ offset {offset}, "
+                    f"{snippet!r}): missing ``--wait`` in the surrounding "
+                    "argument window. Every individual compose-up MUST be "
+                    "gated by ``--wait --wait-timeout <N>`` so compose itself "
+                    "is the synchronization primitive — no external poll loops."
+                )
+                continue
+            timeout_value = _callsite_wait_timeout(text, offset)
+            if timeout_value is None:
+                failures.append(
+                    f"{rel} (callsite #{index} @ offset {offset}): ``--wait`` "
+                    "present but no numeric ``--wait-timeout <N>`` value "
+                    "could be parsed from the adjacent argument window."
+                )
+            elif timeout_value not in ALLOWED_WAIT_TIMEOUTS:
+                failures.append(
+                    f"{rel} (callsite #{index} @ offset {offset}): "
+                    f"``--wait-timeout {timeout_value}`` is not in the "
+                    f"allowed set {sorted(ALLOWED_WAIT_TIMEOUTS)}. Use the "
+                    "named constants COMPOSE_WAIT_TIMEOUT_WARM_SECONDS=120 "
+                    "or COMPOSE_WAIT_TIMEOUT_COLD_SECONDS=300."
+                )
+    assert not failures, "\n".join(failures)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The C# live-test fixture must use protocol readiness, not a port-open sleep
+# loop.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_csharp_fixture_has_no_thread_sleep_port_wait() -> None:
+    fixture_path = (
+        REPO_ROOT
+        / "OPC_UA_Clients"
+        / "Release2"
+        / "IJT_CSharp_Client"
+        / "Tests"
+        / "IJT_CSharp_Client.Tests"
+        / "OpcUaServerFixture.cs"
+    )
+    source = _read(fixture_path)
+    # WaitForPort (the readiness variant) MUST be gone. WaitForPortClosed is
+    # for stale-process cleanup and is explicitly allowlisted.
+    assert "private static bool WaitForPort(" not in source, (
+        "OpcUaServerFixture.cs must not define a Thread.Sleep-based "
+        "WaitForPort happy-path wait. Use ProbeOpcUaReady (which retries "
+        "internally) for readiness, and let ``docker compose up --wait`` "
+        "synchronize on the compose healthcheck for the Docker path."
+    )
+    assert "WaitForPort(_port" not in source, (
+        "OpcUaServerFixture.cs must not call WaitForPort(_port, ...) for "
+        "readiness gating. The protocol probe is the single readiness "
+        "contract."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Every workflow job that runs start_server_on_port.py must upload readiness
+# diagnostics.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_DIAG_DIR_RE = re.compile(r"--diagnostics-dir\s+([^\s\\`]+)")
+
+
+def test_workflow_jobs_pass_diagnostics_dir_and_upload_it() -> None:
+    failures: list[str] = []
+
+    for workflow_path in START_SERVER_WORKFLOWS:
+        workflow = _load_workflow(workflow_path)
+        workflow_rel = workflow_path.relative_to(REPO_ROOT)
+        jobs = workflow.get("jobs") or {}
+
+        for job_id, job in jobs.items():
+            diag_dirs: list[str] = []
+            runs_script = False
+            for step in job.get("steps") or []:
+                run = step.get("run") or ""
+                if "start_server_on_port.py" in run:
+                    runs_script = True
+                    # Allow `--stop` invocations to skip the diag flag.
+                    if "--stop" in run:
+                        continue
+                    matches = _DIAG_DIR_RE.findall(run)
+                    if not matches:
+                        failures.append(
+                            f"{workflow_rel} job '{job_id}' invokes start_server_on_port.py "
+                            "without ``--diagnostics-dir <PATH>``; readiness failures "
+                            "will be undiagnosable in CI."
+                        )
+                    else:
+                        diag_dirs.extend(matches)
+
+            if not runs_script:
+                continue
+
+            # Each diagnostics dir must appear inside at least one upload-artifact
+            # step's ``path:`` block.
+            upload_paths_blobs: list[str] = []
+            for step in job.get("steps") or []:
+                uses = step.get("uses") or ""
+                if uses.startswith("actions/upload-artifact@"):
+                    with_block = step.get("with") or {}
+                    path_val = with_block.get("path") or ""
+                    upload_paths_blobs.append(str(path_val))
+
+            if not upload_paths_blobs:
+                failures.append(
+                    f"{workflow_rel} job '{job_id}' invokes start_server_on_port.py "
+                    "but has no upload-artifact step. Diagnostics manifests would be lost."
+                )
+                continue
+
+            upload_paths_joined = "\n".join(upload_paths_blobs)
+            for diag_dir in diag_dirs:
+                covered = (
+                    diag_dir in upload_paths_joined
+                    or any(
+                        diag_dir.startswith(p.rstrip("/"))
+                        for p in re.split(r"\s+", upload_paths_joined)
+                        if p
+                    )
+                    or any(
+                        p.rstrip("/").startswith(diag_dir.split("/readiness")[0])
+                        for p in re.split(r"\s+", upload_paths_joined)
+                        if p
+                    )
+                )
+                if not covered:
+                    failures.append(
+                        f"{workflow_rel} job '{job_id}': diagnostics-dir {diag_dir!r} "
+                        "is not covered by any upload-artifact path. Existing "
+                        f"upload paths:\n{upload_paths_joined}"
+                    )
+
+    assert not failures, "\n".join(failures)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Compose wait budgets must use the documented warm and cold values.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_compose_wait_timeouts_use_allowed_values_only() -> None:
+    failures: list[str] = []
+    for path in COMPOSE_UP_EXPECTED_CALLSITES:
+        text = _read(path)
+        rel = path.relative_to(REPO_ROOT)
+        for value in _extract_wait_timeouts(text):
+            if value not in ALLOWED_WAIT_TIMEOUTS:
+                failures.append(
+                    f"{rel}: --wait-timeout {value!r} is not in the "
+                    f"allowlist {sorted(ALLOWED_WAIT_TIMEOUTS)}. "
+                    "Use 120 for warm/cached paths and 300 for cold-build paths. "
+                    "Add a new value here only after raising the compose "
+                    "healthcheck budget AND updating this test."
+                )
+    assert not failures, "\n".join(failures)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Direct OPC UA live-server start paths must use OPC UA HELLO readiness.
+#
+# These direct, non-compose server-start surfaces previously used raw port-open
+# loops as the consumer synchronization contract. They must stay on the shared
+# OPC UA HELLO probe instead.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_TCP_ONLY_OPCUA_READINESS_FORBIDDEN: dict[Path, tuple[str, ...]] = {
+    REPO_ROOT / ".github" / "workflows" / "ci.yml": (
+        "Test-NetConnection -ComputerName localhost -Port 40451",
+        "Wait for OPC UA port 40451",
+        "Start-Sleep -Seconds 3",
+    ),
+    REPO_ROOT / "OPC_UA_Servers" / "Release2" / "run_all_tests.py": (
+        "def _wait_for_port(",
+        "_wait_for_port(host, port",
+        "server did not open port",
+    ),
+    REPO_ROOT
+    / "OPC_UA_Clients"
+    / "Release2"
+    / "IJT_Console_Client"
+    / "tests"
+    / "live"
+    / "conftest.py": (
+        "def _wait_for_port(",
+        "_wait_for_port(host, port",
+        "port {port} did not open within",
+    ),
+}
+
+
+def test_direct_opcua_server_start_paths_use_hello_not_tcp_only() -> None:
+    failures: list[str] = []
+    for path, forbidden_snippets in _TCP_ONLY_OPCUA_READINESS_FORBIDDEN.items():
+        assert path.is_file(), f"Missing tracked OPC UA readiness caller: {path}"
+        source = _read(path)
+        rel = path.relative_to(REPO_ROOT)
+        for snippet in forbidden_snippets:
+            if snippet in source:
+                failures.append(
+                    f"{rel}: found TCP-only OPC UA readiness snippet {snippet!r}. "
+                    "Use scripts/ijt_live_readiness.wait_for_opcua_hello or "
+                    "scripts/start_server_on_port.py instead."
+                )
+    assert not failures, "\n".join(failures)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The Web Docker unit-test image must be able to import the shared readiness
+# module.
+#
+# The Web Client Docker test target copies only the Web subtree into /app. A
+# fixed repo-root depth lookup works in a normal checkout but crashes in that
+# flattened Docker layout, so the helper must discover the shared script by
+# walking ancestors and the Dockerfile must vendor the script into /app/scripts.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_web_docker_test_image_vendors_shared_readiness_module() -> None:
+    dockerignore = _read(DOCKERIGNORE)
+    dockerfile = _read(WEB_CLIENT_DOCKERFILE)
+    helper = _read(WEB_CLIENT_READINESS_HELPER)
+
+    assert "COPY scripts/ijt_live_readiness.py /app/scripts/ijt_live_readiness.py" in dockerfile, (
+        "The Web Client Docker test target must vendor scripts/ijt_live_readiness.py "
+        "into /app/scripts so tests/python/_live_server_readiness.py can import "
+        "the shared module inside the flattened /app Docker layout."
+    )
+    assert "parents[5]" not in helper, (
+        "The Web Client readiness helper must not assume the full repository path "
+        "depth. Docker unit tests run from a flattened /app tree, where parents[5] "
+        "raises IndexError during test collection."
+    )
+    assert "def _find_shared_readiness_scripts_dir()" in helper, (
+        "The Web Client readiness helper must locate scripts/ijt_live_readiness.py "
+        "by discovery rather than by hard-coded path depth."
+    )
+    assert "!scripts/" in dockerignore and "!scripts/ijt_live_readiness.py" in dockerignore, (
+        ".dockerignore must allowlist scripts/ijt_live_readiness.py. The Web "
+        "Client test Dockerfile uses the repo root as build context, and the "
+        "root .dockerignore excludes everything by default."
+    )

--- a/tests/test_root_runner.py
+++ b/tests/test_root_runner.py
@@ -237,8 +237,8 @@ def test_live_clients_do_not_duplicate_modern_loader_calls() -> None:
     the same client adds avoidable CI latency.  After the IJT compatibility
     bridge (``_load_ijt_type_definitions``) loads types once per client,
     subsequent standalone ``load_data_type_definitions()`` calls must be
-    removed.  This contract prevents a regression to the previous duplicate-
-    call pattern that Codex flagged.
+    removed. This contract prevents a regression to the previous duplicate-call
+    pattern.
     """
     console_client = (_runner.CONSOLE_DIR / "opcua_client.py").read_text(encoding="utf-8")
     web_connection = (_runner.WEB_CLIENT_DIR / "src" / "python" / "connection.py").read_text(
@@ -324,17 +324,30 @@ def test_opcua_security_docker_rebuilds_when_linux_zip_is_newer() -> None:
     assert 'inspect.StartInfo.ArgumentList.Add("inspect");' in csharp_fixture
     assert "File.GetLastWriteTimeUtc(zipPath) > imageCreatedUtc.Value.UtcDateTime" in csharp_fixture
 
-    # C# must scale compose launch timeout when freshness asks Docker to build.
-    # The previous 30s-only launch path timed out cold CI builds, ignored
-    # WaitForExit's bool return, then read ExitCode from a still-running process.
-    assert "DockerComposeCachedUpTimeoutMs = 30_000" in csharp_fixture
-    assert "DockerComposeBuildUpTimeoutMs = 300_000" in csharp_fixture
+    # C# scales compose launch timeout when freshness asks Docker to build.
+    # Compose launch timeouts use two named ``--wait-timeout`` budgets
+    # (120s warm / 300s cold), so the constants are derived rather than
+    # literal magic numbers. The earlier 30s warm WaitForExit was unsafe
+    # because the server compose healthcheck alone needs roughly 80s.
+    assert "DockerComposeWarmWaitTimeoutSeconds = 120" in csharp_fixture
+    assert "DockerComposeColdWaitTimeoutSeconds = 300" in csharp_fixture
+    assert (
+        "DockerComposeCachedUpTimeoutMs = (DockerComposeWarmWaitTimeoutSeconds + 30) * 1000"
+        in csharp_fixture
+    )
+    assert (
+        "DockerComposeBuildUpTimeoutMs = (DockerComposeColdWaitTimeoutSeconds + 60) * 1000"
+        in csharp_fixture
+    )
     assert "var timeoutMs = DockerComposeUpTimeoutMs(wantsBuild);" in csharp_fixture
     assert "if (!r.WaitForExit(timeoutMs))" in csharp_fixture
     assert "KillProcessTree(r);" in csharp_fixture
     assert "r.BeginOutputReadLine();" in csharp_fixture
     assert "r.BeginErrorReadLine();" in csharp_fixture
+    # The unsafe 30s WaitForExit happy-path is forbidden.
     assert "r.WaitForExit(30_000);\n            if (r.ExitCode == 0)" not in csharp_fixture
+    # Compose ``--wait`` must be wired into the launch invocation.
+    assert 'startInfo.ArgumentList.Add("--wait");' in csharp_fixture
 
     # Console fixture delegates to the shared, dependency-free helper module
     # so this regression test never has to import cryptography / asyncua.

--- a/tests/test_start_server_on_port.py
+++ b/tests/test_start_server_on_port.py
@@ -48,31 +48,19 @@ def test_write_github_env_appends_key_value(monkeypatch: pytest.MonkeyPatch) -> 
         shutil.rmtree(workdir, ignore_errors=True)
 
 
-def test_wait_for_port_returns_elapsed_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
-    times = iter([100.0, 100.6, 100.6])
-    monkeypatch.setattr(_mod.time, "monotonic", lambda: next(times))
-    monkeypatch.setattr(_mod.socket, "create_connection", lambda *args, **kwargs: _DummySocket())
+def test_wait_for_opcua_hello_is_delegated_to_shared_module() -> None:
+    """The script must import the shared HELLO probe; it must not reintroduce
+    a private TCP-only ``_wait_for_port`` loop."""
 
-    elapsed = _mod._wait_for_port(40464, 5)
-
-    assert elapsed == pytest.approx(0.6)
-
-
-def test_wait_for_port_returns_minus_one_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    times = iter([200.0, 201.0, 202.1])
-    sleeps: list[float] = []
-
-    def _raise_oserror(*args, **kwargs):
-        raise OSError("not ready")
-
-    monkeypatch.setattr(_mod.time, "monotonic", lambda: next(times))
-    monkeypatch.setattr(_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
-    monkeypatch.setattr(_mod.socket, "create_connection", _raise_oserror)
-
-    elapsed = _mod._wait_for_port(40464, 2)
-
-    assert elapsed == -1.0
-    assert sleeps == [2]
+    assert hasattr(_mod, "wait_for_opcua_hello"), (
+        "start_server_on_port.py must import wait_for_opcua_hello from "
+        "ijt_live_readiness so the OPC UA HELLO probe is the readiness "
+        "contract."
+    )
+    assert not hasattr(_mod, "_wait_for_port"), (
+        "Readiness must go through ijt_live_readiness.wait_for_opcua_hello. Do not reintroduce "
+        "a TCP-only poll loop in start_server_on_port.py."
+    )
 
 
 def test_default_tmp_base_uses_runner_temp(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -91,6 +79,42 @@ def test_default_tmp_base_falls_back_to_system_temp(monkeypatch: pytest.MonkeyPa
     assert _mod._default_tmp_base() == Path(r"C:\Temp") / "ijt-sim"
 
 
+def _ok_readiness(port: int, *, elapsed: float = 1.25, attempts: int = 1):
+    """Return a ReadinessResult-shaped success object suitable for monkeypatching."""
+
+    import ijt_live_readiness  # type: ignore[import-not-found]
+
+    return ijt_live_readiness.ReadinessResult(
+        ok=True,
+        probe="opcua_hello",
+        host="localhost",
+        port=port,
+        elapsed_seconds=elapsed,
+        attempts=attempts,
+        started_at="2026-05-22T00:00:00.000+00:00",
+        finished_at="2026-05-22T00:00:01.250+00:00",
+        error=None,
+        endpoint=f"opc.tcp://localhost:{port}",
+    )
+
+
+def _fail_readiness(port: int):
+    import ijt_live_readiness  # type: ignore[import-not-found]
+
+    return ijt_live_readiness.ReadinessResult(
+        ok=False,
+        probe="opcua_hello",
+        host="localhost",
+        port=port,
+        elapsed_seconds=30.0,
+        attempts=10,
+        started_at="2026-05-22T00:00:00.000+00:00",
+        finished_at="2026-05-22T00:00:30.000+00:00",
+        error=f"OPC UA HELLO probe to localhost:{port} did not get ACK/ERR within 30.0s",
+        endpoint=f"opc.tcp://localhost:{port}",
+    )
+
+
 def test_start_server_patches_config_and_exports_env(monkeypatch: pytest.MonkeyPatch) -> None:
     workdir = _make_repo_temp_dir()
     try:
@@ -106,10 +130,14 @@ def test_start_server_patches_config_and_exports_env(monkeypatch: pytest.MonkeyP
 
         proc = Mock()
         proc.pid = 4321
+        proc.stdout = Mock()
+        proc.stderr = Mock()
         export = Mock()
 
         monkeypatch.setattr(_mod.subprocess, "Popen", lambda *args, **kwargs: proc)
-        monkeypatch.setattr(_mod, "_wait_for_port", lambda port, timeout: 1.25)
+        monkeypatch.setattr(_mod, "wait_for_opcua_hello", lambda *a, **kw: _ok_readiness(40464))
+        monkeypatch.setattr(_mod, "_spawn_log_pump", lambda *a, **kw: Mock())
+        monkeypatch.setattr(_mod, "write_diagnostic_manifest", lambda *a, **kw: None)
         monkeypatch.setattr(_mod, "_write_github_env", export)
 
         _mod.start_server(40464, server_dir, workdir / "tmp", 30)
@@ -156,8 +184,13 @@ def test_start_server_timeout_kills_process_and_exits(monkeypatch: pytest.Monkey
 
         proc = Mock()
         proc.pid = 9876
+        proc.stdout = Mock()
+        proc.stderr = Mock()
         monkeypatch.setattr(_mod.subprocess, "Popen", lambda *args, **kwargs: proc)
-        monkeypatch.setattr(_mod, "_wait_for_port", lambda port, timeout: -1.0)
+        monkeypatch.setattr(_mod, "wait_for_opcua_hello", lambda *a, **kw: _fail_readiness(40464))
+        monkeypatch.setattr(_mod, "_spawn_log_pump", lambda *a, **kw: Mock())
+        monkeypatch.setattr(_mod, "write_diagnostic_manifest", lambda *a, **kw: None)
+        monkeypatch.setattr(_mod, "capture_process_log_tail", lambda *a, **kw: None)
 
         with pytest.raises(SystemExit) as excinfo:
             _mod.start_server(40464, server_dir, workdir / "tmp", 30)


### PR DESCRIPTION
## Summary

Replaces cross-workflow GHCR tag polling for Browser CI image readiness with a single Integration-owned execution DAG.

Root cause of recurrent flake (run 26257538245 and prior): `Build Browser CI Image` and `Integration` ran as independent workflows synchronizing through GHCR tag presence with a fixed 10-minute consumer budget. On 2026-05-21 the producer pushed the expected tag ~1m43s after the consumer had already timed out. The race is a workflow design defect, not a SHA mismatch.

## What changes

1. Browser image production becomes a reusable workflow called from Integration via `workflow_call`.
2. New Integration jobs `prepare-browser-image-plan` -> conditional `build-browser-image` -> `resolve-browser-image` form an explicit DAG.
3. `live-webclient-browser` consumes `needs.resolve-browser-image.outputs.image_ref` (digest reference). No GHCR polling. No 10-minute blind wait.
4. `fingerprint-<hex>` GHCR cache tag added so repeated same-input Renovate PRs reuse an existing digest. Cache identity is `inputs_fingerprint`; runtime identity is `digest`. `GITHUB_SHA` is provenance only, not validated on consumer side.
5. Non-Browser Integration jobs remain fully parallel.

## Contract guarantees

- `tests/test_ci_synchronization_invariants.py` (new) asserts 8 architectural invariants including: no docker pull polling loop, `needs` edge to resolver, no `secrets: inherit` on the `workflow_call` site, fingerprint-cache tag publication, no SHA-equality consumer check.
- `tests/test_image_pin.py` and `tests/test_root_runner.py` rewritten to validate the new DAG instead of the old tag-polling shape.

## Validation

- `pre-commit run --all-files`: 19/19 hooks green (zizmor, actionlint, ruff, Bandit, ESLint, Stylelint, workflow-policy-guard with embedded pytest).
- `pytest --ignore=OPC_UA_Clients`: 338/338 pass.

## Scope boundary

This PR is one behavior-boundary commit on Browser CI synchronization only. Readiness-budget work for Security/Console/Test Client fixtures will land as a separate root-cause commit (Commit B), not bundled here.

## Expected behavior on this PR

Since no Browser CI image inputs changed on this branch, the planner should emit `plan=pin`, `build-browser-image` should be skipped, and `resolve-browser-image` should return the reviewed digest from `image-pin.json`.
